### PR TITLE
Rename Grasshopper command folders to tools

### DIFF
--- a/src/McpGrasshopperPlugin/GrasshopperMcpHost.cs
+++ b/src/McpGrasshopperPlugin/GrasshopperMcpHost.cs
@@ -1,0 +1,56 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using ModelContextProtocol.Server;
+using ModelContextProtocol.HttpListener;
+using ModelContextProtocol.Protocol;
+
+namespace McpGrasshopperPlugin;
+
+/// <summary>
+/// Hosts an MCP server for Grasshopper using <see cref="HttpListenerMcpTransport"/>.
+/// </summary>
+public sealed class GrasshopperMcpHost : IAsyncDisposable
+{
+    private readonly ServiceProvider _services;
+    private readonly HttpListenerMcpTransport _transport;
+
+    /// <summary>
+    /// Initializes the host for the specified <paramref name="prefix"/>.
+    /// </summary>
+    public GrasshopperMcpHost(string prefix)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        var builder = services.AddMcpServer();
+        builder.WithTools<GrasshopperMCP.Tools.ComponentToolHandler>();
+        builder.WithTools<GH_MCP.Tools.ConnectionToolHandler>();
+        builder.WithTools<GrasshopperMCP.Tools.DocumentToolHandler>();
+        builder.WithTools<GrasshopperMCP.Tools.GeometryToolHandler>();
+        builder.WithTools<GH_MCP.Tools.IntentToolHandler>();
+        _services = services.BuildServiceProvider();
+        var options = _services.GetRequiredService<IOptions<McpServerOptions>>().Value;
+        var loggerFactory = _services.GetService<ILoggerFactory>();
+        _transport = new HttpListenerMcpTransport(prefix, options, loggerFactory, _services);
+    }
+
+    /// <summary>Occurs when an MCP message is received.</summary>
+    public event Action<JsonRpcMessage>? MessageReceived
+    {
+        add => _transport.MessageReceived += value;
+        remove => _transport.MessageReceived -= value;
+    }
+
+    /// <summary>Starts listening for requests.</summary>
+    public Task StartAsync(CancellationToken cancellationToken = default) => _transport.StartAsync(cancellationToken);
+
+    /// <summary>Stops listening for requests.</summary>
+    public Task StopAsync() => _transport.StopAsync();
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        await _transport.DisposeAsync();
+        await _services.DisposeAsync();
+    }
+}

--- a/src/McpGrasshopperPlugin/McpGrasshopperPlugin.csproj
+++ b/src/McpGrasshopperPlugin/McpGrasshopperPlugin.csproj
@@ -1,0 +1,51 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+	
+  <PropertyGroup>
+    <!-- Select the framework(s) you wish to target.
+        Rhino 6: net45
+        Rhino 7: net48
+        Rhino 8 Windows: net48, net7.0, net7.0-windows, net7.0-windows10.0.22000.0, etc
+        Rhino 8 Mac: net7.0, net7.0-macos, net7.0-macos12.0, etc
+    -->
+    <TargetFrameworks>net7.0-windows;net7.0;net48</TargetFrameworks>
+    <EnableDynamicLoading>true</EnableDynamicLoading>
+    <TargetExt>.gha</TargetExt>
+    <NoWarn>NU1701;NETSDK1086</NoWarn>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
+  </PropertyGroup>
+  
+  <PropertyGroup>
+    <!-- Specifies information for Assembly and Yak -->
+    <Version>1.0</Version>
+    <Title>McpGrasshopperPlugin</Title>
+    <Company>McpGrasshopperPlugin Authors</Company>
+    <Description>Description of McpGrasshopperPlugin</Description>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="Grasshopper" Version="8.0.23304.9001" ExcludeAssets="runtime" />
+    <PackageReference Include="RhinoCommon" Version="8.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../ModelContextProtocol.HttpListener/ModelContextProtocol.HttpListener.csproj" />
+  </ItemGroup>
+  
+  <!-- For Windows only builds -->
+  <PropertyGroup Condition="$(TargetFramework.Contains('-windows')) or $(TargetFramework.StartsWith('net4'))">
+    <UseWindowsForms>true</UseWindowsForms>
+  </PropertyGroup>
+
+  <!-- Reference WinForms for .NET 7.0 on macOS -->
+  <ItemGroup Condition="!($(TargetFramework.Contains('-windows')) or $(TargetFramework.StartsWith('net4')))">
+    <!-- Rhino 8.11 and later you can use this -->
+    <!-- <FrameworkReference Include="Microsoft.WindowsDesktop.App.WindowsForms" /> -->
+    
+    <!-- Rhino 8.10 and earlier -->
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net48" Version="1.0.3" ExcludeAssets="all" GeneratePathProperty="true" />
+    <Reference Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net48)\build\.NETFramework\v4.8\System.Windows.Forms.dll" Private="False" />
+    <PackageReference Include="System.Drawing.Common" Version="7.0.0" ExcludeAssets="runtime" />
+  </ItemGroup>
+
+</Project>

--- a/src/McpGrasshopperPlugin/McpGrasshopperPluginInfo.cs
+++ b/src/McpGrasshopperPlugin/McpGrasshopperPluginInfo.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Drawing;
+using Grasshopper;
+using Grasshopper.Kernel;
+
+namespace McpGrasshopperPlugin
+{
+  public class McpGrasshopperPluginInfo : GH_AssemblyInfo
+  {
+    public override string Name => "McpGrasshopperPlugin Info";
+
+    //Return a 24x24 pixel bitmap to represent this GHA library.
+    public override Bitmap Icon => null;
+
+    //Return a short string describing the purpose of this GHA library.
+    public override string Description => "";
+
+    public override Guid Id => new Guid("dfbcda10-6fa8-4839-a512-8ee41d0bdf5f");
+
+    //Return a string identifying you or your company.
+    public override string AuthorName => "";
+
+    //Return a string representing your preferred contact details.
+    public override string AuthorContact => "";
+
+    //Return a string representing the version.  This returns the same version as the assembly.
+    public override string AssemblyVersion => GetType().Assembly.GetName().Version.ToString();
+  }
+}

--- a/src/McpGrasshopperPlugin/McpListenerComponent.cs
+++ b/src/McpGrasshopperPlugin/McpListenerComponent.cs
@@ -1,0 +1,73 @@
+using Grasshopper.Kernel;
+using System;
+using System.Collections.Generic;
+using ModelContextProtocol.Protocol;
+using System.Text.Json;
+
+namespace McpGrasshopperPlugin;
+
+/// <summary>
+/// Example Grasshopper component that starts <see cref="HttpListenerMcpTransport"/>
+/// and outputs received JSON-RPC messages and log lines.
+/// </summary>
+
+public class McpListenerComponent : GH_Component
+{
+    private GrasshopperMcpHost? _server;
+    private CancellationTokenSource? _cts;
+    private readonly List<string> _logs = new();
+    private readonly List<string> _messages = new();
+
+    public McpListenerComponent() : base("MCP Listener", "MCP", "Start MCP server", "MCP", "Server") { }
+
+    protected override void RegisterInputParams(GH_InputParamManager pManager)
+    {
+        pManager.AddBooleanParameter("On", "On", "Start server", GH_ParamAccess.item, false);
+        pManager.AddTextParameter("Prefix", "P", "HTTP prefix", GH_ParamAccess.item, "http://localhost:3001/mcp/");
+    }
+
+    protected override void RegisterOutputParams(GH_OutputParamManager pManager)
+    {
+        pManager.AddTextParameter("Messages", "M", "Received JSON-RPC messages", GH_ParamAccess.list);
+        pManager.AddTextParameter("Logs", "L", "Log messages", GH_ParamAccess.list);
+    }
+
+    protected override void SolveInstance(IGH_DataAccess da)
+    {
+        bool on = false;
+        string prefix = "";
+        if (!da.GetData(0, ref on)) return;
+        if (!da.GetData(1, ref prefix)) return;
+
+        if (on && _server == null)
+        {
+            _server = new GrasshopperMcpHost(prefix);
+            _server.MessageReceived += OnMessage;
+            _cts = new CancellationTokenSource();
+            _server.StartAsync(_cts.Token).Wait();
+            _logs.Add($"Server started at {prefix}");
+        }
+        else if (!on && _server != null)
+        {
+            _cts?.Cancel();
+            _server.StopAsync().Wait();
+            _server.DisposeAsync().AsTask().Wait();
+            _server.MessageReceived -= OnMessage;
+            _server = null;
+            _cts?.Dispose();
+            _cts = null;
+            _logs.Add("Server stopped");
+        }
+
+        da.SetDataList(0, _messages);
+        da.SetDataList(1, _logs);
+    }
+
+    private void OnMessage(JsonRpcMessage msg)
+    {
+        _messages.Add(JsonSerializer.Serialize(msg, McpJsonUtilities.DefaultOptions.GetTypeInfo(typeof(JsonRpcMessage))));
+        ExpireSolution(true);
+    }
+
+    public override Guid ComponentGuid => new("6b8ec8b1-599f-4d5a-8244-e2d7f0a2ea76");
+}

--- a/src/McpGrasshopperPlugin/Models/Connection.cs
+++ b/src/McpGrasshopperPlugin/Models/Connection.cs
@@ -1,0 +1,58 @@
+using System;
+
+namespace GH_MCP.Models
+{
+    /// <summary>
+    /// Represents a connection endpoint on a component.
+    /// </summary>
+    public class Connection
+    {
+        /// <summary>
+        /// Component GUID
+        /// </summary>
+        public string ComponentId { get; set; }
+
+        /// <summary>
+        /// Parameter name (input or output)
+        /// </summary>
+        public string ParameterName { get; set; }
+
+        /// <summary>
+        /// Parameter index if name is not specified
+        /// </summary>
+        public int? ParameterIndex { get; set; }
+
+        /// <summary>
+        /// Checks whether the connection information is valid
+        /// </summary>
+        public bool IsValid()
+        {
+            return !string.IsNullOrEmpty(ComponentId) && 
+                   (!string.IsNullOrEmpty(ParameterName) || ParameterIndex.HasValue);
+        }
+    }
+
+    /// <summary>
+    /// Represents a pairing between two components.
+    /// </summary>
+    public class ConnectionPairing
+    {
+        /// <summary>
+        /// Source connection (output)
+        /// </summary>
+        public Connection Source { get; set; }
+
+        /// <summary>
+        /// Target connection (input)
+        /// </summary>
+        public Connection Target { get; set; }
+
+        /// <summary>
+        /// Checks whether the pairing is valid
+        /// </summary>
+        public bool IsValid()
+        {
+            return Source != null && Target != null && Source.IsValid() && Target.IsValid();
+        }
+    }
+}

--- a/src/McpGrasshopperPlugin/Models/ToolRequest.cs
+++ b/src/McpGrasshopperPlugin/Models/ToolRequest.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace GrasshopperMCP.Models
+{
+    /// <summary>
+    /// Represents a tool request coming from a client.
+    /// </summary>
+    public class ToolRequest
+    {
+        /// <summary>
+        /// Tool type
+        /// </summary>
+        [JsonProperty("type")]
+        public string Type { get; set; }
+
+        /// <summary>
+        /// Tool parameters
+        /// </summary>
+        [JsonProperty("parameters")]
+        public Dictionary<string, object> Parameters { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the request.
+        /// </summary>
+        /// <param name="type">Tool type</param>
+        /// <param name="parameters">Tool parameters</param>
+        public ToolRequest(string type, Dictionary<string, object> parameters = null)
+        {
+            Type = type;
+            Parameters = parameters ?? new Dictionary<string, object>();
+        }
+
+        /// <summary>
+        /// Gets the specified parameter value.
+        /// </summary>
+        /// <typeparam name="T">Parameter type</typeparam>
+        /// <param name="name">Parameter name</param>
+        /// <returns>Parameter value</returns>
+        public T GetParameter<T>(string name)
+        {
+            if (Parameters.TryGetValue(name, out object value))
+            {
+                if (value is T typedValue)
+                {
+                    return typedValue;
+                }
+                
+                // Try to convert
+                try
+                {
+                    return (T)Convert.ChangeType(value, typeof(T));
+                }
+                catch
+                {
+                    // Convert from JObject if needed
+                    if (value is Newtonsoft.Json.Linq.JObject jObject)
+                    {
+                        return jObject.ToObject<T>();
+                    }
+                    
+                    // Convert from JArray if needed
+                    if (value is Newtonsoft.Json.Linq.JArray jArray)
+                    {
+                        return jArray.ToObject<T>();
+                    }
+                }
+            }
+            
+            // Return default if conversion fails
+            return default;
+        }
+    }
+
+    /// <summary>
+    /// Response returned to the caller after a tool executes.
+    /// </summary>
+    public class Response
+    {
+        /// <summary>
+        /// Indicates whether the request was successful
+        /// </summary>
+        [JsonProperty("success")]
+        public bool Success { get; set; }
+
+        /// <summary>
+        /// Result data if successful
+        /// </summary>
+        [JsonProperty("data")]
+        public object Data { get; set; }
+
+        /// <summary>
+        /// Error message if any
+        /// </summary>
+        [JsonProperty("error")]
+        public string Error { get; set; }
+
+        /// <summary>
+        /// Creates a success response
+        /// </summary>
+        /// <param name="data">Optional data</param>
+        /// <returns>The response instance</returns>
+        public static Response Ok(object data = null)
+        {
+            return new Response
+            {
+                Success = true,
+                Data = data
+            };
+        }
+
+        /// <summary>
+        /// Creates an error response
+        /// </summary>
+        /// <param name="errorMessage">Error message</param>
+        /// <returns>The response instance</returns>
+        public static Response CreateError(string errorMessage)
+        {
+            return new Response
+            {
+                Success = false,
+                Data = null,
+                Error = errorMessage
+            };
+        }
+    }
+}

--- a/src/McpGrasshopperPlugin/Properties/launchSettings.json
+++ b/src/McpGrasshopperPlugin/Properties/launchSettings.json
@@ -1,0 +1,20 @@
+{
+  "profiles": {
+    "Rhino 8 - netcore": {
+      "commandName": "Executable",
+      "executablePath": "C:\\Program Files\\Rhino 8\\System\\Rhino.exe",
+      "commandLineArgs": "/netcore /runscript=\"_Grasshopper\"",
+      "environmentVariables": {
+        "RHINO_PACKAGE_DIRS": "$(ProjectDir)$(OutputPath)\\"
+      }
+    },
+    "Rhino 8 - netfx": {
+      "commandName": "Executable",
+      "executablePath": "C:\\Program Files\\Rhino 8\\System\\Rhino.exe",
+      "commandLineArgs": "/netfx /runscript=\"_Grasshopper\"",
+      "environmentVariables": {
+        "RHINO_PACKAGE_DIRS": "$(ProjectDir)$(OutputPath)\\"
+      }
+    },
+  }
+}

--- a/src/McpGrasshopperPlugin/Resources/ComponentKnowledgeBase.json
+++ b/src/McpGrasshopperPlugin/Resources/ComponentKnowledgeBase.json
@@ -1,0 +1,215 @@
+{
+  "components": [
+    {
+      "name": "Point",
+      "category": "Params",
+      "subcategory": "Geometry",
+      "description": "Creates a point at the specified coordinates",
+      "inputs": [
+        {"name": "X", "type": "Number", "description": "X coordinate"},
+        {"name": "Y", "type": "Number", "description": "Y coordinate"},
+        {"name": "Z", "type": "Number", "description": "Z coordinate"}
+      ],
+      "outputs": [
+        {"name": "Pt", "type": "Point", "description": "Point"}
+      ]
+    },
+    {
+      "name": "XY Plane",
+      "category": "Vector",
+      "subcategory": "Plane",
+      "description": "Creates an XY plane at the world origin or at a specified point",
+      "inputs": [
+        {"name": "Origin", "type": "Point", "description": "Origin point", "optional": true}
+      ],
+      "outputs": [
+        {"name": "Plane", "type": "Plane", "description": "XY plane"}
+      ]
+    },
+    {
+      "name": "Box",
+      "category": "Surface",
+      "subcategory": "Primitive",
+      "description": "Creates a box from a base plane and dimensions",
+      "inputs": [
+        {"name": "Base", "type": "Plane", "description": "Base plane"},
+        {"name": "X Size", "type": "Number", "description": "Size in X direction"},
+        {"name": "Y Size", "type": "Number", "description": "Size in Y direction"},
+        {"name": "Z Size", "type": "Number", "description": "Size in Z direction"}
+      ],
+      "outputs": [
+        {"name": "Box", "type": "Brep", "description": "Box geometry"}
+      ]
+    },
+    {
+      "name": "Circle",
+      "category": "Curve",
+      "subcategory": "Primitive",
+      "description": "Creates a circle from a plane and radius",
+      "inputs": [
+        {"name": "Plane", "type": "Plane", "description": "Circle plane"},
+        {"name": "Radius", "type": "Number", "description": "Circle radius"}
+      ],
+      "outputs": [
+        {"name": "Circle", "type": "Curve", "description": "Circle curve"}
+      ]
+    },
+    {
+      "name": "Number Slider",
+      "category": "Params",
+      "subcategory": "Input",
+      "description": "Slider for numeric input",
+      "inputs": [],
+      "outputs": [
+        {"name": "Number", "type": "Number", "description": "Slider value"}
+      ],
+      "defaultSettings": {
+        "min": 0,
+        "max": 10,
+        "value": 5
+      }
+    },
+    {
+      "name": "Panel",
+      "category": "Params",
+      "subcategory": "Input",
+      "description": "Text panel for input or output",
+      "inputs": [
+        {"name": "Input", "type": "Any", "description": "Any input", "optional": true}
+      ],
+      "outputs": [
+        {"name": "Output", "type": "Text", "description": "Panel text"}
+      ]
+    },
+    {
+      "name": "Voronoi",
+      "category": "Surface",
+      "subcategory": "Triangulation",
+      "description": "Creates a Voronoi diagram from points",
+      "inputs": [
+        {"name": "Points", "type": "Point", "description": "Input points"},
+        {"name": "Radius", "type": "Number", "description": "Cell radius", "optional": true},
+        {"name": "Plane", "type": "Plane", "description": "Base plane", "optional": true}
+      ],
+      "outputs": [
+        {"name": "Cells", "type": "Curve", "description": "Voronoi cells"},
+        {"name": "Vertices", "type": "Point", "description": "Voronoi vertices"}
+      ]
+    },
+    {
+      "name": "Populate 3D",
+      "category": "Vector",
+      "subcategory": "Grid",
+      "description": "Creates a 3D grid of points",
+      "inputs": [
+        {"name": "Base", "type": "Plane", "description": "Base plane"},
+        {"name": "Size X", "type": "Number", "description": "Size in X direction"},
+        {"name": "Size Y", "type": "Number", "description": "Size in Y direction"},
+        {"name": "Size Z", "type": "Number", "description": "Size in Z direction"},
+        {"name": "Count X", "type": "Integer", "description": "Count in X direction"},
+        {"name": "Count Y", "type": "Integer", "description": "Count in Y direction"},
+        {"name": "Count Z", "type": "Integer", "description": "Count in Z direction"}
+      ],
+      "outputs": [
+        {"name": "Points", "type": "Point", "description": "3D grid of points"}
+      ]
+    },
+    {
+      "name": "Boundary Surfaces",
+      "category": "Surface",
+      "subcategory": "Freeform",
+      "description": "Creates boundary surfaces from curves",
+      "inputs": [
+        {"name": "Curves", "type": "Curve", "description": "Input curves"}
+      ],
+      "outputs": [
+        {"name": "Surfaces", "type": "Surface", "description": "Boundary surfaces"}
+      ]
+    },
+    {
+      "name": "Extrude",
+      "category": "Surface",
+      "subcategory": "Freeform",
+      "description": "Extrudes curves or surfaces",
+      "inputs": [
+        {"name": "Base", "type": "Geometry", "description": "Base geometry"},
+        {"name": "Direction", "type": "Vector", "description": "Extrusion direction"},
+        {"name": "Distance", "type": "Number", "description": "Extrusion distance"}
+      ],
+      "outputs": [
+        {"name": "Result", "type": "Brep", "description": "Extruded geometry"}
+      ]
+    }
+  ],
+  "patterns": [
+    {
+      "name": "3D Box",
+      "description": "Creates a simple 3D box",
+      "components": [
+        {"type": "XY Plane", "x": 100, "y": 100, "id": "plane"},
+        {"type": "Number Slider", "x": 100, "y": 200, "id": "sliderX", "settings": {"min": 0, "max": 50, "value": 20}},
+        {"type": "Number Slider", "x": 100, "y": 250, "id": "sliderY", "settings": {"min": 0, "max": 50, "value": 20}},
+        {"type": "Number Slider", "x": 100, "y": 300, "id": "sliderZ", "settings": {"min": 0, "max": 50, "value": 20}},
+        {"type": "Box", "x": 400, "y": 200, "id": "box"}
+      ],
+      "connections": [
+        {"source": "plane", "sourceParam": "Plane", "target": "box", "targetParam": "Base"},
+        {"source": "sliderX", "sourceParam": "Number", "target": "box", "targetParam": "X Size"},
+        {"source": "sliderY", "sourceParam": "Number", "target": "box", "targetParam": "Y Size"},
+        {"source": "sliderZ", "sourceParam": "Number", "target": "box", "targetParam": "Z Size"}
+      ]
+    },
+    {
+      "name": "3D Voronoi",
+      "description": "Creates a 3D Voronoi pattern within a box",
+      "components": [
+        {"type": "XY Plane", "x": 100, "y": 100, "id": "plane"},
+        {"type": "Number Slider", "x": 100, "y": 200, "id": "sizeX", "settings": {"min": 0, "max": 100, "value": 50}},
+        {"type": "Number Slider", "x": 100, "y": 250, "id": "sizeY", "settings": {"min": 0, "max": 100, "value": 50}},
+        {"type": "Number Slider", "x": 100, "y": 300, "id": "sizeZ", "settings": {"min": 0, "max": 100, "value": 50}},
+        {"type": "Number Slider", "x": 100, "y": 350, "id": "countX", "settings": {"min": 1, "max": 20, "value": 10}},
+        {"type": "Number Slider", "x": 100, "y": 400, "id": "countY", "settings": {"min": 1, "max": 20, "value": 10}},
+        {"type": "Number Slider", "x": 100, "y": 450, "id": "countZ", "settings": {"min": 1, "max": 20, "value": 10}},
+        {"type": "Populate 3D", "x": 400, "y": 250, "id": "populate"},
+        {"type": "Voronoi", "x": 600, "y": 250, "id": "voronoi"}
+      ],
+      "connections": [
+        {"source": "plane", "sourceParam": "Plane", "target": "populate", "targetParam": "Base"},
+        {"source": "sizeX", "sourceParam": "Number", "target": "populate", "targetParam": "Size X"},
+        {"source": "sizeY", "sourceParam": "Number", "target": "populate", "targetParam": "Size Y"},
+        {"source": "sizeZ", "sourceParam": "Number", "target": "populate", "targetParam": "Size Z"},
+        {"source": "countX", "sourceParam": "Number", "target": "populate", "targetParam": "Count X"},
+        {"source": "countY", "sourceParam": "Number", "target": "populate", "targetParam": "Count Y"},
+        {"source": "countZ", "sourceParam": "Number", "target": "populate", "targetParam": "Count Z"},
+        {"source": "populate", "sourceParam": "Points", "target": "voronoi", "targetParam": "Points"}
+      ]
+    },
+    {
+      "name": "Circle",
+      "description": "Creates a simple circle",
+      "components": [
+        {"type": "XY Plane", "x": 100, "y": 100, "id": "plane"},
+        {"type": "Number Slider", "x": 100, "y": 200, "id": "radius", "settings": {"min": 0, "max": 50, "value": 10}},
+        {"type": "Circle", "x": 400, "y": 150, "id": "circle"}
+      ],
+      "connections": [
+        {"source": "plane", "sourceParam": "Plane", "target": "circle", "targetParam": "Plane"},
+        {"source": "radius", "sourceParam": "Number", "target": "circle", "targetParam": "Radius"}
+      ]
+    }
+  ],
+  "intents": [
+    {
+      "keywords": ["box", "cube", "rectangular", "prism"],
+      "pattern": "3D Box"
+    },
+    {
+      "keywords": ["voronoi", "cell", "diagram", "3d", "cellular"],
+      "pattern": "3D Voronoi"
+    },
+    {
+      "keywords": ["circle", "round", "disc"],
+      "pattern": "Circle"
+    }
+  ]
+}

--- a/src/McpGrasshopperPlugin/Tools/ComponentToolHandler.cs
+++ b/src/McpGrasshopperPlugin/Tools/ComponentToolHandler.cs
@@ -1,0 +1,610 @@
+using System;
+using System.Collections.Generic;
+using GrasshopperMCP.Models;
+using Grasshopper.Kernel;
+using Grasshopper.Kernel.Parameters;
+using Grasshopper.Kernel.Special;
+using Rhino;
+using Rhino.Geometry;
+using Grasshopper;
+using System.Linq;
+using Grasshopper.Kernel.Components;
+using System.Threading;
+using GH_MCP.Utils;
+
+namespace GrasshopperMCP.Tools
+{
+    /// <summary>
+    /// </summary>
+    public static class ComponentToolHandler
+    {
+        /// <summary>
+        /// </summary>
+        public static object AddComponent(ToolRequest tool)
+        {
+            string type = tool.GetParameter<string>("type");
+            double x = tool.GetParameter<double>("x");
+            double y = tool.GetParameter<double>("y");
+            
+            if (string.IsNullOrEmpty(type))
+            {
+                throw new ArgumentException("Component type is required");
+            }
+            
+            string normalizedType = FuzzyMatcher.GetClosestComponentName(type);
+            
+            RhinoApp.WriteLine($"AddComponent request: type={type}, normalized={normalizedType}, x={x}, y={y}");
+            
+            object result = null;
+            Exception exception = null;
+            
+            RhinoApp.InvokeOnUiThread(new Action(() =>
+            {
+                try
+                {
+                    var doc = Grasshopper.Instances.ActiveCanvas?.Document;
+                    if (doc == null)
+                    {
+                        throw new InvalidOperationException("No active Grasshopper document");
+                    }
+                    
+                    IGH_DocumentObject component = null;
+                    
+                    bool loggedComponentTypes = false;
+                    if (!loggedComponentTypes)
+                    {
+                        var availableTypes = Grasshopper.Instances.ComponentServer.ObjectProxies
+                            .Select(p => p.Desc.Name)
+                            .OrderBy(n => n)
+                            .ToList();
+                        
+                        RhinoApp.WriteLine($"Available component types: {string.Join(", ", availableTypes.Take(50))}...");
+                        loggedComponentTypes = true;
+                    }
+                    
+                    switch (normalizedType.ToLowerInvariant())
+                    {
+                        case "xy plane":
+                            component = CreateComponentByName("XY Plane");
+                            break;
+                        case "xz plane":
+                            component = CreateComponentByName("XZ Plane");
+                            break;
+                        case "yz plane":
+                            component = CreateComponentByName("YZ Plane");
+                            break;
+                        case "plane 3pt":
+                            component = CreateComponentByName("Plane 3Pt");
+                            break;
+                            
+                        case "box":
+                            component = CreateComponentByName("Box");
+                            break;
+                        case "sphere":
+                            component = CreateComponentByName("Sphere");
+                            break;
+                        case "cylinder":
+                            component = CreateComponentByName("Cylinder");
+                            break;
+                        case "cone":
+                            component = CreateComponentByName("Cone");
+                            break;
+                        case "circle":
+                            component = CreateComponentByName("Circle");
+                            break;
+                        case "rectangle":
+                            component = CreateComponentByName("Rectangle");
+                            break;
+                        case "line":
+                            component = CreateComponentByName("Line");
+                            break;
+                            
+                        case "point":
+                        case "pt":
+                        case "pointparam":
+                        case "param_point":
+                            component = new Param_Point();
+                            break;
+                        case "curve":
+                        case "crv":
+                        case "curveparam":
+                        case "param_curve":
+                            component = new Param_Curve();
+                            break;
+                        case "circleparam":
+                        case "param_circle":
+                            component = new Param_Circle();
+                            break;
+                        case "lineparam":
+                        case "param_line":
+                            component = new Param_Line();
+                            break;
+                        case "panel":
+                        case "gh_panel":
+                            component = new GH_Panel();
+                            break;
+                        case "slider":
+                        case "numberslider":
+                        case "gh_numberslider":
+                            var slider = new GH_NumberSlider();
+                            slider.SetInitCode("0.0 < 0.5 < 1.0");
+                            component = slider;
+                            break;
+                        case "number":
+                        case "num":
+                        case "integer":
+                        case "int":
+                        case "param_number":
+                        case "param_integer":
+                            component = new Param_Number();
+                            break;
+                        case "construct point":
+                        case "constructpoint":
+                        case "pt xyz":
+                        case "xyz":
+                            var pointProxy = Grasshopper.Instances.ComponentServer.ObjectProxies
+                                .FirstOrDefault(p => p.Desc.Name.Equals("Construct Point", StringComparison.OrdinalIgnoreCase));
+                            if (pointProxy != null)
+                            {
+                                component = pointProxy.CreateInstance();
+                            }
+                            else
+                            {
+                                throw new ArgumentException("Construct Point component not found");
+                            }
+                            break;
+                        default:
+                            Guid componentGuid;
+                            if (Guid.TryParse(type, out componentGuid))
+                            {
+                                component = Grasshopper.Instances.ComponentServer.EmitObject(componentGuid);
+                                RhinoApp.WriteLine($"Attempting to create component by GUID: {componentGuid}");
+                            }
+                            
+                            if (component == null)
+                            {
+                                RhinoApp.WriteLine($"Attempting to find component by name: {type}");
+                                var obj = Grasshopper.Instances.ComponentServer.ObjectProxies
+                                    .FirstOrDefault(p => p.Desc.Name.Equals(type, StringComparison.OrdinalIgnoreCase));
+                                    
+                                if (obj != null)
+                                {
+                                    RhinoApp.WriteLine($"Found component: {obj.Desc.Name}");
+                                    component = obj.CreateInstance();
+                                }
+                                else
+                                {
+                                    RhinoApp.WriteLine($"Attempting to find component by partial name match: {type}");
+                                    obj = Grasshopper.Instances.ComponentServer.ObjectProxies
+                                        .FirstOrDefault(p => p.Desc.Name.IndexOf(type, StringComparison.OrdinalIgnoreCase) >= 0);
+                                        
+                                    if (obj != null)
+                                    {
+                                        RhinoApp.WriteLine($"Found component by partial match: {obj.Desc.Name}");
+                                        component = obj.CreateInstance();
+                                    }
+                                }
+                            }
+                            
+                            if (component == null)
+                            {
+                                var possibleMatches = Grasshopper.Instances.ComponentServer.ObjectProxies
+                                    .Where(p => p.Desc.Name.IndexOf(type, StringComparison.OrdinalIgnoreCase) >= 0)
+                                    .Select(p => p.Desc.Name)
+                                    .Take(10)
+                                    .ToList();
+                                
+                                var errorMessage = $"Unknown component type: {type}";
+                                if (possibleMatches.Any())
+                                {
+                                    errorMessage += $". Possible matches: {string.Join(", ", possibleMatches)}";
+                                }
+                                
+                                throw new ArgumentException(errorMessage);
+                            }
+                            break;
+                    }
+                    
+                    if (component != null)
+                    {
+                        if (component.Attributes == null)
+                        {
+                            RhinoApp.WriteLine("Component attributes are null, creating new attributes");
+                            component.CreateAttributes();
+                        }
+                        
+                        component.Attributes.Pivot = new System.Drawing.PointF((float)x, (float)y);
+                        
+                        doc.AddObject(component, false);
+                        
+                        doc.NewSolution(false);
+                        
+                        result = new
+                        {
+                            id = component.InstanceGuid.ToString(),
+                            type = component.GetType().Name,
+                            name = component.NickName,
+                            x = component.Attributes.Pivot.X,
+                            y = component.Attributes.Pivot.Y
+                        };
+                    }
+                    else
+                    {
+                        throw new InvalidOperationException("Failed to create component");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    exception = ex;
+                    RhinoApp.WriteLine($"Error in AddComponent: {ex.Message}");
+                }
+            }));
+            
+            while (result == null && exception == null)
+            {
+                Thread.Sleep(10);
+            }
+            
+            if (exception != null)
+            {
+                throw exception;
+            }
+            
+            return result;
+        }
+        
+        /// <summary>
+        /// </summary>
+        public static object ConnectComponents(ToolRequest tool)
+        {
+            var fromData = tool.GetParameter<Dictionary<string, object>>("from");
+            var toData = tool.GetParameter<Dictionary<string, object>>("to");
+            
+            if (fromData == null || toData == null)
+            {
+                throw new ArgumentException("Source and target component information are required");
+            }
+            
+            object result = null;
+            Exception exception = null;
+            
+            RhinoApp.InvokeOnUiThread(new Action(() =>
+            {
+                try
+                {
+                    var doc = Grasshopper.Instances.ActiveCanvas?.Document;
+                    if (doc == null)
+                    {
+                        throw new InvalidOperationException("No active Grasshopper document");
+                    }
+                    
+                    string fromIdStr = fromData["id"].ToString();
+                    string fromParamName = fromData["parameterName"].ToString();
+                    
+                    string toIdStr = toData["id"].ToString();
+                    string toParamName = toData["parameterName"].ToString();
+                    
+                    Guid fromId, toId;
+                    if (!Guid.TryParse(fromIdStr, out fromId) || !Guid.TryParse(toIdStr, out toId))
+                    {
+                        throw new ArgumentException("Invalid component ID format");
+                    }
+                    
+                    IGH_Component fromComponent = doc.FindComponent(fromId) as IGH_Component;
+                    IGH_Component toComponent = doc.FindComponent(toId) as IGH_Component;
+                    
+                    if (fromComponent == null || toComponent == null)
+                    {
+                        throw new ArgumentException("Source or target component not found");
+                    }
+                    
+                    IGH_Param fromParam = null;
+                    foreach (var param in fromComponent.Params.Output)
+                    {
+                        if (param.Name.Equals(fromParamName, StringComparison.OrdinalIgnoreCase))
+                        {
+                            fromParam = param;
+                            break;
+                        }
+                    }
+                    
+                    IGH_Param toParam = null;
+                    foreach (var param in toComponent.Params.Input)
+                    {
+                        if (param.Name.Equals(toParamName, StringComparison.OrdinalIgnoreCase))
+                        {
+                            toParam = param;
+                            break;
+                        }
+                    }
+                    
+                    if (fromParam == null || toParam == null)
+                    {
+                        throw new ArgumentException("Source or target parameter not found");
+                    }
+                    
+                    toParam.AddSource(fromParam);
+                    
+                    doc.NewSolution(false);
+                    
+                    result = new
+                    {
+                        from = new
+                        {
+                            id = fromComponent.InstanceGuid.ToString(),
+                            name = fromComponent.NickName,
+                            parameter = fromParam.Name
+                        },
+                        to = new
+                        {
+                            id = toComponent.InstanceGuid.ToString(),
+                            name = toComponent.NickName,
+                            parameter = toParam.Name
+                        }
+                    };
+                }
+                catch (Exception ex)
+                {
+                    exception = ex;
+                    RhinoApp.WriteLine($"Error in ConnectComponents: {ex.Message}");
+                }
+            }));
+            
+            while (result == null && exception == null)
+            {
+                Thread.Sleep(10);
+            }
+            
+            if (exception != null)
+            {
+                throw exception;
+            }
+            
+            return result;
+        }
+        
+        /// <summary>
+        /// </summary>
+        public static object SetComponentValue(ToolRequest tool)
+        {
+            string idStr = tool.GetParameter<string>("id");
+            string value = tool.GetParameter<string>("value");
+            
+            if (string.IsNullOrEmpty(idStr))
+            {
+                throw new ArgumentException("Component ID is required");
+            }
+            
+            object result = null;
+            Exception exception = null;
+            
+            RhinoApp.InvokeOnUiThread(new Action(() =>
+            {
+                try
+                {
+                    var doc = Grasshopper.Instances.ActiveCanvas?.Document;
+                    if (doc == null)
+                    {
+                        throw new InvalidOperationException("No active Grasshopper document");
+                    }
+                    
+                    Guid id;
+                    if (!Guid.TryParse(idStr, out id))
+                    {
+                        throw new ArgumentException("Invalid component ID format");
+                    }
+                    
+                    IGH_DocumentObject component = doc.FindObject(id, true);
+                    if (component == null)
+                    {
+                        throw new ArgumentException($"Component with ID {idStr} not found");
+                    }
+                    
+                    if (component is GH_Panel panel)
+                    {
+                        panel.UserText = value;
+                    }
+                    else if (component is GH_NumberSlider slider)
+                    {
+                        double doubleValue;
+                        if (double.TryParse(value, out doubleValue))
+                        {
+                            slider.SetSliderValue((decimal)doubleValue);
+                        }
+                        else
+                        {
+                            throw new ArgumentException("Invalid slider value format");
+                        }
+                    }
+                    else if (component is IGH_Component ghComponent)
+                    {
+                        if (ghComponent.Params.Input.Count > 0)
+                        {
+                            var param = ghComponent.Params.Input[0];
+                            if (param is Param_String stringParam)
+                            {
+                                stringParam.PersistentData.Clear();
+                                stringParam.PersistentData.Append(new Grasshopper.Kernel.Types.GH_String(value));
+                            }
+                            else if (param is Param_Number numberParam)
+                            {
+                                double doubleValue;
+                                if (double.TryParse(value, out doubleValue))
+                                {
+                                    numberParam.PersistentData.Clear();
+                                    numberParam.PersistentData.Append(new Grasshopper.Kernel.Types.GH_Number(doubleValue));
+                                }
+                                else
+                                {
+                                    throw new ArgumentException("Invalid number value format");
+                                }
+                            }
+                            else
+                            {
+                                throw new ArgumentException($"Cannot set value for parameter type {param.GetType().Name}");
+                            }
+                        }
+                        else
+                        {
+                            throw new ArgumentException("Component has no input parameters");
+                        }
+                    }
+                    else
+                    {
+                        throw new ArgumentException($"Cannot set value for component type {component.GetType().Name}");
+                    }
+                    
+                    doc.NewSolution(false);
+                    
+                    result = new
+                    {
+                        id = component.InstanceGuid.ToString(),
+                        type = component.GetType().Name,
+                        value = value
+                    };
+                }
+                catch (Exception ex)
+                {
+                    exception = ex;
+                    RhinoApp.WriteLine($"Error in SetComponentValue: {ex.Message}");
+                }
+            }));
+            
+            while (result == null && exception == null)
+            {
+                Thread.Sleep(10);
+            }
+            
+            if (exception != null)
+            {
+                throw exception;
+            }
+            
+            return result;
+        }
+        
+        /// <summary>
+        /// </summary>
+        public static object GetComponentInfo(ToolRequest tool)
+        {
+            string idStr = tool.GetParameter<string>("id");
+            
+            if (string.IsNullOrEmpty(idStr))
+            {
+                throw new ArgumentException("Component ID is required");
+            }
+            
+            object result = null;
+            Exception exception = null;
+            
+            RhinoApp.InvokeOnUiThread(new Action(() =>
+            {
+                try
+                {
+                    var doc = Grasshopper.Instances.ActiveCanvas?.Document;
+                    if (doc == null)
+                    {
+                        throw new InvalidOperationException("No active Grasshopper document");
+                    }
+                    
+                    Guid id;
+                    if (!Guid.TryParse(idStr, out id))
+                    {
+                        throw new ArgumentException("Invalid component ID format");
+                    }
+                    
+                    IGH_DocumentObject component = doc.FindObject(id, true);
+                    if (component == null)
+                    {
+                        throw new ArgumentException($"Component with ID {idStr} not found");
+                    }
+                    
+                    var componentInfo = new Dictionary<string, object>
+                    {
+                        { "id", component.InstanceGuid.ToString() },
+                        { "type", component.GetType().Name },
+                        { "name", component.NickName },
+                        { "description", component.Description }
+                    };
+                    
+                    if (component is IGH_Component ghComponent)
+                    {
+                        var inputs = new List<Dictionary<string, object>>();
+                        foreach (var param in ghComponent.Params.Input)
+                        {
+                            inputs.Add(new Dictionary<string, object>
+                            {
+                                { "name", param.Name },
+                                { "nickname", param.NickName },
+                                { "description", param.Description },
+                                { "type", param.GetType().Name },
+                                { "dataType", param.TypeName }
+                            });
+                        }
+                        componentInfo["inputs"] = inputs;
+                        
+                        var outputs = new List<Dictionary<string, object>>();
+                        foreach (var param in ghComponent.Params.Output)
+                        {
+                            outputs.Add(new Dictionary<string, object>
+                            {
+                                { "name", param.Name },
+                                { "nickname", param.NickName },
+                                { "description", param.Description },
+                                { "type", param.GetType().Name },
+                                { "dataType", param.TypeName }
+                            });
+                        }
+                        componentInfo["outputs"] = outputs;
+                    }
+                    
+                    if (component is GH_Panel panel)
+                    {
+                        componentInfo["value"] = panel.UserText;
+                    }
+                    
+                    if (component is GH_NumberSlider slider)
+                    {
+                        componentInfo["value"] = (double)slider.CurrentValue;
+                        componentInfo["minimum"] = (double)slider.Slider.Minimum;
+                        componentInfo["maximum"] = (double)slider.Slider.Maximum;
+                    }
+                    
+                    result = componentInfo;
+                }
+                catch (Exception ex)
+                {
+                    exception = ex;
+                    RhinoApp.WriteLine($"Error in GetComponentInfo: {ex.Message}");
+                }
+            }));
+            
+            while (result == null && exception == null)
+            {
+                Thread.Sleep(10);
+            }
+            
+            if (exception != null)
+            {
+                throw exception;
+            }
+            
+            return result;
+        }
+        
+        private static IGH_DocumentObject CreateComponentByName(string name)
+        {
+            var obj = Grasshopper.Instances.ComponentServer.ObjectProxies
+                .FirstOrDefault(p => p.Desc.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
+                
+            if (obj != null)
+            {
+                return obj.CreateInstance();
+            }
+            else
+            {
+                throw new ArgumentException($"Component with name {name} not found");
+            }
+        }
+    }
+}

--- a/src/McpGrasshopperPlugin/Tools/ConnectionToolHandler.cs
+++ b/src/McpGrasshopperPlugin/Tools/ConnectionToolHandler.cs
@@ -1,0 +1,453 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using GrasshopperMCP.Models;
+using GH_MCP.Models;
+using Grasshopper;
+using Grasshopper.Kernel;
+using Grasshopper.Kernel.Parameters;
+using Rhino;
+using Newtonsoft.Json;
+using GH_MCP.Utils;
+
+namespace GH_MCP.Tools
+{
+    /// <summary>
+    /// </summary>
+    public class ConnectionToolHandler
+    {
+        /// <summary>
+        /// </summary>
+        public static object ConnectComponents(ToolRequest tool)
+        {
+            if (!tool.Parameters.TryGetValue("sourceId", out object sourceIdObj) || sourceIdObj == null)
+            {
+                return Response.CreateError("Missing required parameter: sourceId");
+            }
+            string sourceId = sourceIdObj.ToString();
+
+            string sourceParam = null;
+            int? sourceParamIndex = null;
+            if (tool.Parameters.TryGetValue("sourceParam", out object sourceParamObj) && sourceParamObj != null)
+            {
+                sourceParam = sourceParamObj.ToString();
+                sourceParam = FuzzyMatcher.GetClosestParameterName(sourceParam);
+            }
+            else if (tool.Parameters.TryGetValue("sourceParamIndex", out object sourceParamIndexObj) && sourceParamIndexObj != null)
+            {
+                if (int.TryParse(sourceParamIndexObj.ToString(), out int index))
+                {
+                    sourceParamIndex = index;
+                }
+            }
+
+            if (!tool.Parameters.TryGetValue("targetId", out object targetIdObj) || targetIdObj == null)
+            {
+                return Response.CreateError("Missing required parameter: targetId");
+            }
+            string targetId = targetIdObj.ToString();
+
+            string targetParam = null;
+            int? targetParamIndex = null;
+            if (tool.Parameters.TryGetValue("targetParam", out object targetParamObj) && targetParamObj != null)
+            {
+                targetParam = targetParamObj.ToString();
+                targetParam = FuzzyMatcher.GetClosestParameterName(targetParam);
+            }
+            else if (tool.Parameters.TryGetValue("targetParamIndex", out object targetParamIndexObj) && targetParamIndexObj != null)
+            {
+                if (int.TryParse(targetParamIndexObj.ToString(), out int index))
+                {
+                    targetParamIndex = index;
+                }
+            }
+
+            RhinoApp.WriteLine($"Connecting: sourceId={sourceId}, sourceParam={sourceParam}, targetId={targetId}, targetParam={targetParam}");
+
+            var connection = new ConnectionPairing
+            {
+                Source = new Connection
+                {
+                    ComponentId = sourceId,
+                    ParameterName = sourceParam,
+                    ParameterIndex = sourceParamIndex
+                },
+                Target = new Connection
+                {
+                    ComponentId = targetId,
+                    ParameterName = targetParam,
+                    ParameterIndex = targetParamIndex
+                }
+            };
+
+            if (!connection.IsValid())
+            {
+                return Response.CreateError("Invalid connection parameters");
+            }
+
+            object result = null;
+            Exception exception = null;
+
+            RhinoApp.InvokeOnUiThread(new Action(() =>
+            {
+                try
+                {
+                    var doc = Instances.ActiveCanvas?.Document;
+                    if (doc == null)
+                    {
+                        exception = new InvalidOperationException("No active Grasshopper document");
+                        return;
+                    }
+
+                    Guid sourceGuid;
+                    if (!Guid.TryParse(connection.Source.ComponentId, out sourceGuid))
+                    {
+                        exception = new ArgumentException($"Invalid source component ID: {connection.Source.ComponentId}");
+                        return;
+                    }
+
+                    var sourceComponent = doc.FindObject(sourceGuid, true);
+                    if (sourceComponent == null)
+                    {
+                        exception = new ArgumentException($"Source component not found: {connection.Source.ComponentId}");
+                        return;
+                    }
+
+                    Guid targetGuid;
+                    if (!Guid.TryParse(connection.Target.ComponentId, out targetGuid))
+                    {
+                        exception = new ArgumentException($"Invalid target component ID: {connection.Target.ComponentId}");
+                        return;
+                    }
+
+                    var targetComponent = doc.FindObject(targetGuid, true);
+                    if (targetComponent == null)
+                    {
+                        exception = new ArgumentException($"Target component not found: {connection.Target.ComponentId}");
+                        return;
+                    }
+
+                    if (sourceComponent is IGH_Param && ((IGH_Param)sourceComponent).Kind == GH_ParamKind.input)
+                    {
+                        exception = new ArgumentException("Source component cannot be an input parameter");
+                        return;
+                    }
+
+                    if (targetComponent is IGH_Param && ((IGH_Param)targetComponent).Kind == GH_ParamKind.output)
+                    {
+                        exception = new ArgumentException("Target component cannot be an output parameter");
+                        return;
+                    }
+
+                    IGH_Param sourceParameter = GetParameter(sourceComponent, connection.Source, false);
+                    if (sourceParameter == null)
+                    {
+                        exception = new ArgumentException($"Source parameter not found: {connection.Source.ParameterName ?? connection.Source.ParameterIndex.ToString()}");
+                        return;
+                    }
+
+                    IGH_Param targetParameter = GetParameter(targetComponent, connection.Target, true);
+                    if (targetParameter == null)
+                    {
+                        exception = new ArgumentException($"Target parameter not found: {connection.Target.ParameterName ?? connection.Target.ParameterIndex.ToString()}");
+                        return;
+                    }
+
+                    if (!AreParametersCompatible(sourceParameter, targetParameter))
+                    {
+                        exception = new ArgumentException($"Parameters are not compatible: {sourceParameter.GetType().Name} cannot connect to {targetParameter.GetType().Name}");
+                        return;
+                    }
+
+                    if (targetParameter.SourceCount > 0)
+                    {
+                        targetParameter.RemoveAllSources();
+                    }
+
+                    targetParameter.AddSource(sourceParameter);
+                    
+                    targetParameter.CollectData();
+                    targetParameter.ComputeData();
+                    
+                    doc.NewSolution(false);
+
+                    result = new
+                    {
+                        success = true,
+                        message = "Connection created successfully",
+                        sourceId = connection.Source.ComponentId,
+                        targetId = connection.Target.ComponentId,
+                        sourceParam = sourceParameter.Name,
+                        targetParam = targetParameter.Name,
+                        sourceType = sourceParameter.GetType().Name,
+                        targetType = targetParameter.GetType().Name,
+                        sourceDescription = sourceParameter.Description,
+                        targetDescription = targetParameter.Description
+                    };
+                }
+                catch (Exception ex)
+                {
+                    exception = ex;
+                    RhinoApp.WriteLine($"Error in ConnectComponents: {ex.Message}");
+                }
+            }));
+
+            while (result == null && exception == null)
+            {
+                Thread.Sleep(10);
+            }
+
+            if (exception != null)
+            {
+                return Response.CreateError($"Error executing tool 'connect_components': {exception.Message}");
+            }
+
+            return Response.Ok(result);
+        }
+
+        /// <summary>
+        /// </summary>
+        private static IGH_Param GetParameter(IGH_DocumentObject docObj, Connection connection, bool isInput)
+        {
+            if (docObj is IGH_Param param)
+            {
+                return param;
+            }
+            
+            if (docObj is IGH_Component component)
+            {
+                IList<IGH_Param> parameters = isInput ? component.Params.Input : component.Params.Output;
+                
+                if (parameters == null || parameters.Count == 0)
+                {
+                    return null;
+                }
+                
+                if (parameters.Count == 1 && string.IsNullOrEmpty(connection.ParameterName) && !connection.ParameterIndex.HasValue)
+                {
+                    return parameters[0];
+                }
+                
+                if (!string.IsNullOrEmpty(connection.ParameterName))
+                {
+                    foreach (var p in parameters)
+                    {
+                        if (string.Equals(p.Name, connection.ParameterName, StringComparison.OrdinalIgnoreCase))
+                        {
+                            return p;
+                        }
+                    }
+                    
+                    foreach (var p in parameters)
+                    {
+                        if (p.Name.IndexOf(connection.ParameterName, StringComparison.OrdinalIgnoreCase) >= 0)
+                        {
+                            return p;
+                        }
+                    }
+
+                    foreach (var p in parameters)
+                    {
+                        if (string.Equals(p.NickName, connection.ParameterName, StringComparison.OrdinalIgnoreCase))
+                        {
+                            return p;
+                        }
+                    }
+                }
+                
+                if (connection.ParameterIndex.HasValue)
+                {
+                    int index = connection.ParameterIndex.Value;
+                    if (index >= 0 && index < parameters.Count)
+                    {
+                        return parameters[index];
+                    }
+                }
+            }
+            
+            return null;
+        }
+
+        /// <summary>
+        /// </summary>
+        private static bool AreParametersCompatible(IGH_Param source, IGH_Param target)
+        {
+            if (source.GetType() == target.GetType())
+            {
+                return true;
+            }
+
+            var sourceType = source.Type;
+            var targetType = target.Type;
+            
+            RhinoApp.WriteLine($"Parameter types: source={sourceType.Name}, target={targetType.Name}");
+            RhinoApp.WriteLine($"Parameter names: source={source.Name}, target={target.Name}");
+            
+            bool isSourceNumeric = IsNumericType(source);
+            bool isTargetNumeric = IsNumericType(target);
+            
+            if (isSourceNumeric && isTargetNumeric)
+            {
+                return true;
+            }
+
+            bool isSourceCurve = source is Param_Curve;
+            bool isTargetCurve = target is Param_Curve;
+            bool isSourceGeometry = source is Param_Geometry;
+            bool isTargetGeometry = target is Param_Geometry;
+
+            if ((isSourceCurve && isTargetGeometry) || (isSourceGeometry && isTargetCurve))
+            {
+                return true;
+            }
+
+            bool isSourcePoint = source is Param_Point;
+            bool isTargetPoint = target is Param_Point;
+            bool isSourceVector = source is Param_Vector;
+            bool isTargetVector = target is Param_Vector;
+
+            if ((isSourcePoint && isTargetVector) || (isSourceVector && isTargetPoint))
+            {
+                return true;
+            }
+
+            var sourceDoc = source.OnPingDocument();
+            var targetDoc = target.OnPingDocument();
+            
+            if (sourceDoc != null && targetDoc != null)
+            {
+                IGH_Component sourceComponent = FindComponentForParam(sourceDoc, source);
+                IGH_Component targetComponent = FindComponentForParam(targetDoc, target);
+                
+                if (sourceComponent != null && targetComponent != null)
+                {
+                    RhinoApp.WriteLine($"Components: source={sourceComponent.Name}, target={targetComponent.Name}");
+                    RhinoApp.WriteLine($"Component GUIDs: source={sourceComponent.ComponentGuid}, target={targetComponent.ComponentGuid}");
+                    
+                    if (IsPlaneComponent(sourceComponent) && RequiresPlaneInput(targetComponent))
+                    {
+                        RhinoApp.WriteLine("Connecting plane component to geometry component that requires plane input");
+                        return true;
+                    }
+                    
+                    if (sourceComponent.Name.Contains("Number") && targetComponent.Name.Contains("Circle"))
+                    {
+                        if (targetComponent.ComponentGuid.ToString() == "d1028c72-ff86-4057-9eb0-36c687a4d98c")
+                        {
+                            RhinoApp.WriteLine("Detected connection to Circle parameter container instead of Circle component");
+                            return false;
+                        }
+                        if (targetComponent.ComponentGuid.ToString() == "807b86e3-be8d-4970-92b5-f8cdcb45b06b")
+                        {
+                            return true;
+                        }
+                    }
+                    
+                    if (IsPlaneComponent(sourceComponent) && targetComponent.Name.Contains("Box"))
+                    {
+                        RhinoApp.WriteLine("Connecting plane component to box component");
+                        return true;
+                    }
+                }
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// </summary>
+        private static bool IsNumericType(IGH_Param param)
+        {
+            return param is Param_Integer || 
+                   param is Param_Number || 
+                   param is Param_Time;
+        }
+
+        /// <summary>
+        /// </summary>
+        private static IGH_Component FindComponentForParam(GH_Document doc, IGH_Param param)
+        {
+            foreach (var obj in doc.Objects)
+            {
+                if (obj is IGH_Component comp)
+                {
+                    foreach (var outParam in comp.Params.Output)
+                    {
+                        if (outParam.InstanceGuid == param.InstanceGuid)
+                        {
+                            return comp;
+                        }
+                    }
+                    
+                    foreach (var inParam in comp.Params.Input)
+                    {
+                        if (inParam.InstanceGuid == param.InstanceGuid)
+                        {
+                            return comp;
+                        }
+                    }
+                }
+            }
+            
+            return null;
+        }
+        
+        /// <summary>
+        /// </summary>
+        private static bool IsPlaneComponent(IGH_Component component)
+        {
+            if (component == null)
+                return false;
+                
+            string name = component.Name.ToLowerInvariant();
+            if (name.Contains("plane"))
+                return true;
+                
+            if (component.ComponentGuid.ToString() == "896a1e5e-c2ac-4996-a6d8-5b61157080b3")
+                return true;
+                
+            return false;
+        }
+        
+        /// <summary>
+        /// </summary>
+        private static bool RequiresPlaneInput(IGH_Component component)
+        {
+            if (component == null)
+                return false;
+                
+            foreach (var param in component.Params.Input)
+            {
+                string paramName = param.Name.ToLowerInvariant();
+                if (paramName.Contains("plane") || paramName.Contains("base"))
+                    return true;
+            }
+            
+            string name = component.Name.ToLowerInvariant();
+            return name.Contains("box") || 
+                   name.Contains("rectangle") || 
+                   name.Contains("circle") || 
+                   name.Contains("cylinder") || 
+                   name.Contains("cone");
+        }
+    }
+
+    public class ConnectionPairing
+    {
+        public Connection Source { get; set; }
+        public Connection Target { get; set; }
+
+        public bool IsValid()
+        {
+            return Source != null && Target != null;
+        }
+    }
+
+    public class Connection
+    {
+        public string ComponentId { get; set; }
+        public string ParameterName { get; set; }
+        public int? ParameterIndex { get; set; }
+    }
+}

--- a/src/McpGrasshopperPlugin/Tools/DocumentToolHandler.cs
+++ b/src/McpGrasshopperPlugin/Tools/DocumentToolHandler.cs
@@ -1,0 +1,176 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using GrasshopperMCP.Models;
+using Grasshopper.Kernel;
+using Rhino;
+using System.Linq;
+using System.Threading;
+
+namespace GrasshopperMCP.Tools
+{
+    /// <summary>
+    /// </summary>
+    public static class DocumentToolHandler
+    {
+        /// <summary>
+        /// </summary>
+        public static object GetDocumentInfo(ToolRequest tool)
+        {
+            object result = null;
+            Exception exception = null;
+            
+            RhinoApp.InvokeOnUiThread(new Action(() =>
+            {
+                try
+                {
+                    var doc = Grasshopper.Instances.ActiveCanvas?.Document;
+                    if (doc == null)
+                    {
+                        throw new InvalidOperationException("No active Grasshopper document");
+                    }
+                    
+                    var components = new List<object>();
+                    foreach (var obj in doc.Objects)
+                    {
+                        var componentInfo = new Dictionary<string, object>
+                        {
+                            { "id", obj.InstanceGuid.ToString() },
+                            { "type", obj.GetType().Name },
+                            { "name", obj.NickName }
+                        };
+                        
+                        components.Add(componentInfo);
+                    }
+                    
+                    var docInfo = new Dictionary<string, object>
+                    {
+                        { "name", doc.DisplayName },
+                        { "path", doc.FilePath },
+                        { "componentCount", doc.Objects.Count },
+                        { "components", components }
+                    };
+                    
+                    result = docInfo;
+                }
+                catch (Exception ex)
+                {
+                    exception = ex;
+                    RhinoApp.WriteLine($"Error in GetDocumentInfo: {ex.Message}");
+                }
+            }));
+            
+            while (result == null && exception == null)
+            {
+                Thread.Sleep(10);
+            }
+            
+            if (exception != null)
+            {
+                throw exception;
+            }
+            
+            return result;
+        }
+        
+        /// <summary>
+        /// </summary>
+        public static object ClearDocument(ToolRequest tool)
+        {
+            object result = null;
+            Exception exception = null;
+            
+            RhinoApp.InvokeOnUiThread(new Action(() =>
+            {
+                try
+                {
+                    var doc = Grasshopper.Instances.ActiveCanvas?.Document;
+                    if (doc == null)
+                    {
+                        throw new InvalidOperationException("No active Grasshopper document");
+                    }
+                    
+                    var objectsToRemove = doc.Objects.ToList();
+                    
+                    var essentialComponents = objectsToRemove.Where(obj => 
+                        obj.NickName.Contains("MCP") || 
+                        obj.NickName.Contains("Claude") ||
+                        obj.GetType().Name.Contains("GH_MCP") ||
+                        obj.Description.Contains("Machine Control Protocol") ||
+                        obj.GetType().Name.Contains("GH_BooleanToggle") ||
+                        obj.GetType().Name.Contains("GH_Panel") ||
+                        obj.NickName.Contains("Toggle") ||
+                        obj.NickName.Contains("Status") ||
+                        obj.NickName.Contains("Panel")
+                    ).ToList();
+                    
+                    foreach (var component in essentialComponents)
+                    {
+                        objectsToRemove.Remove(component);
+                    }
+                    
+                    doc.RemoveObjects(objectsToRemove, false);
+                    
+                    doc.NewSolution(false);
+                    
+                    result = new
+                    {
+                        success = true,
+                        message = "Document cleared"
+                    };
+                }
+                catch (Exception ex)
+                {
+                    exception = ex;
+                    RhinoApp.WriteLine($"Error in ClearDocument: {ex.Message}");
+                }
+            }));
+            
+            while (result == null && exception == null)
+            {
+                Thread.Sleep(10);
+            }
+            
+            if (exception != null)
+            {
+                throw exception;
+            }
+            
+            return result;
+        }
+        
+        /// <summary>
+        /// </summary>
+        public static object SaveDocument(ToolRequest tool)
+        {
+            string path = tool.GetParameter<string>("path");
+            if (string.IsNullOrEmpty(path))
+            {
+                throw new ArgumentException("Save path is required");
+            }
+            
+            return new
+            {
+                success = false,
+                message = "SaveDocument is temporarily disabled due to API compatibility issues. Please save the document manually."
+            };
+        }
+        
+        /// <summary>
+        /// </summary>
+        public static object LoadDocument(ToolRequest tool)
+        {
+            string path = tool.GetParameter<string>("path");
+            if (string.IsNullOrEmpty(path))
+            {
+                throw new ArgumentException("Load path is required");
+            }
+            
+            return new
+            {
+                success = false,
+                message = "LoadDocument is temporarily disabled due to API compatibility issues. Please load the document manually."
+            };
+        }
+    }
+}

--- a/src/McpGrasshopperPlugin/Tools/GeometryToolHandler.cs
+++ b/src/McpGrasshopperPlugin/Tools/GeometryToolHandler.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Collections.Generic;
+using GrasshopperMCP.Models;
+using Grasshopper.Kernel;
+using Rhino.Geometry;
+using Newtonsoft.Json.Linq;
+using System.Linq;
+using Rhino;
+
+namespace GrasshopperMCP.Tools
+{
+    /// <summary>
+    /// </summary>
+    public static class GeometryToolHandler
+    {
+        /// <summary>
+        /// </summary>
+        public static object CreatePoint(ToolRequest tool)
+        {
+            double x = tool.GetParameter<double>("x");
+            double y = tool.GetParameter<double>("y");
+            double z = tool.GetParameter<double>("z");
+            
+            Point3d point = new Point3d(x, y, z);
+            
+            return new
+            {
+                id = Guid.NewGuid().ToString(),
+                x = point.X,
+                y = point.Y,
+                z = point.Z
+            };
+        }
+        
+        /// <summary>
+        /// </summary>
+        public static object CreateCurve(ToolRequest tool)
+        {
+            var pointsData = tool.GetParameter<JArray>("points");
+            
+            if (pointsData == null || pointsData.Count < 2)
+            {
+                throw new ArgumentException("At least 2 points are required to create a curve");
+            }
+            
+            List<Point3d> points = new List<Point3d>();
+            foreach (var pointData in pointsData)
+            {
+                double x = pointData["x"].Value<double>();
+                double y = pointData["y"].Value<double>();
+                double z = pointData["z"]?.Value<double>() ?? 0.0;
+                
+                points.Add(new Point3d(x, y, z));
+            }
+            
+            Curve curve;
+            if (points.Count == 2)
+            {
+                curve = new LineCurve(points[0], points[1]);
+            }
+            else
+            {
+                curve = Curve.CreateInterpolatedCurve(points, 3);
+            }
+            
+            return new
+            {
+                id = Guid.NewGuid().ToString(),
+                pointCount = points.Count,
+                length = curve.GetLength()
+            };
+        }
+        
+        /// <summary>
+        /// </summary>
+        public static object CreateCircle(ToolRequest tool)
+        {
+            var centerData = tool.GetParameter<JObject>("center");
+            double radius = tool.GetParameter<double>("radius");
+            
+            if (centerData == null)
+            {
+                throw new ArgumentException("Center point is required");
+            }
+            
+            if (radius <= 0)
+            {
+                throw new ArgumentException("Radius must be greater than 0");
+            }
+            
+            double x = centerData["x"].Value<double>();
+            double y = centerData["y"].Value<double>();
+            double z = centerData["z"]?.Value<double>() ?? 0.0;
+            
+            Point3d center = new Point3d(x, y, z);
+            
+            Circle circle = new Circle(center, radius);
+            
+            return new
+            {
+                id = Guid.NewGuid().ToString(),
+                center = new { x = center.X, y = center.Y, z = center.Z },
+                radius = circle.Radius,
+                circumference = circle.Circumference
+            };
+        }
+    }
+}

--- a/src/McpGrasshopperPlugin/Tools/GrasshopperToolRegistry.cs
+++ b/src/McpGrasshopperPlugin/Tools/GrasshopperToolRegistry.cs
@@ -1,0 +1,162 @@
+using System;
+using System.Collections.Generic;
+using GH_MCP.Tools;
+using GrasshopperMCP.Models;
+using GrasshopperMCP.Tools;
+using Grasshopper.Kernel;
+using Rhino;
+using System.Linq;
+
+namespace GH_MCP.Tools
+{
+    /// <summary>
+    /// Registry for Grasshopper tools. Provides registration and execution
+    /// helpers used by the MCP host.
+    /// </summary>
+    public static class GrasshopperToolRegistry
+    {
+        // Maps tool names to their handler delegates.
+        private static readonly Dictionary<string, Func<ToolRequest, object>> ToolHandlers = new();
+
+        /// <summary>
+        /// Initializes the registry and registers all builtin tools.
+        /// </summary>
+        public static void Initialize()
+        {
+            // Register geometry tools
+            RegisterGeometryTools();
+            
+            // Register component tools
+            RegisterComponentTools();
+            
+            // Register document tools
+            RegisterDocumentTools();
+            
+            // Register intent tools
+            RegisterIntentTools();
+            
+            RhinoApp.WriteLine("GH_MCP: Tool registry initialized.");
+        }
+
+        /// <summary>
+        /// Registers geometry-related tools
+        /// </summary>
+        private static void RegisterGeometryTools()
+        {
+            // Create point
+            RegisterTool("create_point", GeometryToolHandler.CreatePoint);
+            
+            // Create curve
+            RegisterTool("create_curve", GeometryToolHandler.CreateCurve);
+            
+            // Create circle
+            RegisterTool("create_circle", GeometryToolHandler.CreateCircle);
+        }
+
+        /// <summary>
+        /// Registers component manipulation tools
+        /// </summary>
+        private static void RegisterComponentTools()
+        {
+            // Add component
+            RegisterTool("add_component", ComponentToolHandler.AddComponent);
+            
+            // Connect components
+            RegisterTool("connect_components", ConnectionToolHandler.ConnectComponents);
+            
+            // Set component value
+            RegisterTool("set_component_value", ComponentToolHandler.SetComponentValue);
+            
+            // Get component information
+            RegisterTool("get_component_info", ComponentToolHandler.GetComponentInfo);
+        }
+
+        /// <summary>
+        /// Registers document-related tools
+        /// </summary>
+        private static void RegisterDocumentTools()
+        {
+            // Get document info
+            RegisterTool("get_document_info", DocumentToolHandler.GetDocumentInfo);
+            
+            // Clear document
+            RegisterTool("clear_document", DocumentToolHandler.ClearDocument);
+            
+            // Save document
+            RegisterTool("save_document", DocumentToolHandler.SaveDocument);
+            
+            // Load document
+            RegisterTool("load_document", DocumentToolHandler.LoadDocument);
+        }
+
+        /// <summary>
+        /// Registers intent tools
+        /// </summary>
+        private static void RegisterIntentTools()
+        {
+            // Create pattern
+            RegisterTool("create_pattern", IntentToolHandler.CreatePattern);
+            
+            // Get available patterns
+            RegisterTool("get_available_patterns", IntentToolHandler.GetAvailablePatterns);
+            
+            RhinoApp.WriteLine("GH_MCP: Intent tools registered.");
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="toolType">Tool name</param>
+        /// <param name="handler">Handler delegate</param>
+        public static void RegisterTool(string toolType, Func<ToolRequest, object> handler)
+        {
+            if (string.IsNullOrEmpty(toolType))
+                throw new ArgumentNullException(nameof(toolType));
+                
+            if (handler == null)
+                throw new ArgumentNullException(nameof(handler));
+                
+            ToolHandlers[toolType] = handler;
+            RhinoApp.WriteLine($"GH_MCP: Registered tool handler for '{toolType}'");
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="tool">The tool to execute.</param>
+        /// <returns>Tool execution result.</returns>
+        public static Response ExecuteTool(ToolRequest tool)
+        {
+            if (tool == null)
+            {
+                return Response.CreateError("Tool is null");
+            }
+
+            if (string.IsNullOrEmpty(tool.Type))
+            {
+                return Response.CreateError("Tool type is null or empty");
+            }
+
+            if (ToolHandlers.TryGetValue(tool.Type, out var handler))
+            {
+                try
+                {
+                    var result = handler(tool);
+                    return Response.Ok(result);
+                }
+                catch (Exception ex)
+                {
+                    RhinoApp.WriteLine($"GH_MCP: Error executing tool '{tool.Type}': {ex.Message}");
+                    return Response.CreateError($"Error executing tool '{tool.Type}': {ex.Message}");
+                }
+            }
+
+            return Response.CreateError($"No handler registered for tool type '{tool.Type}'");
+        }
+
+        /// <summary>
+        /// </summary>
+        public static List<string> GetRegisteredToolTypes()
+        {
+            return ToolHandlers.Keys.ToList();
+        }
+    }
+}

--- a/src/McpGrasshopperPlugin/Tools/IntentToolHandler.cs
+++ b/src/McpGrasshopperPlugin/Tools/IntentToolHandler.cs
@@ -1,0 +1,159 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using GrasshopperMCP.Models;
+using GrasshopperMCP.Tools;
+using GH_MCP.Models;
+using GH_MCP.Utils;
+using Rhino;
+using Newtonsoft.Json;
+
+namespace GH_MCP.Tools
+{
+    /// <summary>
+    /// </summary>
+    public class IntentToolHandler
+    {
+        private static Dictionary<string, string> _componentIdMap = new Dictionary<string, string>();
+
+        /// <summary>
+        /// </summary>
+        public static object CreatePattern(ToolRequest tool)
+        {
+            if (!tool.Parameters.TryGetValue("description", out object descriptionObj) || descriptionObj == null)
+            {
+                return Response.CreateError("Missing required parameter: description");
+            }
+            string description = descriptionObj.ToString();
+
+            string patternName = IntentRecognizer.RecognizeIntent(description);
+            if (string.IsNullOrEmpty(patternName))
+            {
+                return Response.CreateError($"Could not recognize intent from description: {description}");
+            }
+
+            RhinoApp.WriteLine($"Recognized intent: {patternName}");
+
+            var (components, connections) = IntentRecognizer.GetPatternDetails(patternName);
+            if (components.Count == 0)
+            {
+                return Response.CreateError($"Pattern '{patternName}' has no components defined");
+            }
+
+            _componentIdMap.Clear();
+
+            foreach (var component in components)
+            {
+                try
+                {
+                    var addToolRequest = new ToolRequest(
+                        "add_component",
+                        new Dictionary<string, object>
+                        {
+                            { "type", component.Type },
+                            { "x", component.X },
+                            { "y", component.Y }
+                        }
+                    );
+
+                    if (component.Settings != null)
+                    {
+                        foreach (var setting in component.Settings)
+                        {
+                            addToolRequest.Parameters.Add(setting.Key, setting.Value);
+                        }
+                    }
+
+                    var result = ComponentToolHandler.AddComponent(addToolRequest);
+                    if (result is Response response && response.Success && response.Data != null)
+                    {
+                        string componentId = response.Data.ToString();
+                        _componentIdMap[component.Id] = componentId;
+                        RhinoApp.WriteLine($"Created component {component.Type} with ID {componentId}");
+                    }
+                    else
+                    {
+                        RhinoApp.WriteLine($"Failed to create component {component.Type}");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    RhinoApp.WriteLine($"Error creating component {component.Type}: {ex.Message}");
+                }
+
+                Thread.Sleep(100);
+            }
+
+            foreach (var connection in connections)
+            {
+                try
+                {
+                    if (!_componentIdMap.TryGetValue(connection.SourceId, out string sourceId) ||
+                        !_componentIdMap.TryGetValue(connection.TargetId, out string targetId))
+                    {
+                        RhinoApp.WriteLine($"Could not find component IDs for connection {connection.SourceId} -> {connection.TargetId}");
+                        continue;
+                    }
+
+                    var connectToolRequest = new ToolRequest(
+                        "connect_components",
+                        new Dictionary<string, object>
+                        {
+                            { "sourceId", sourceId },
+                            { "sourceParam", connection.SourceParam },
+                            { "targetId", targetId },
+                            { "targetParam", connection.TargetParam }
+                        }
+                    );
+
+                    var result = ConnectionToolHandler.ConnectComponents(connectToolRequest);
+                    if (result is Response response && response.Success)
+                    {
+                        RhinoApp.WriteLine($"Connected {connection.SourceId}.{connection.SourceParam} -> {connection.TargetId}.{connection.TargetParam}");
+                    }
+                    else
+                    {
+                        RhinoApp.WriteLine($"Failed to connect {connection.SourceId}.{connection.SourceParam} -> {connection.TargetId}.{connection.TargetParam}");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    RhinoApp.WriteLine($"Error creating connection: {ex.Message}");
+                }
+
+                Thread.Sleep(100);
+            }
+
+            return Response.Ok(new
+            {
+                Pattern = patternName,
+                ComponentCount = components.Count,
+                ConnectionCount = connections.Count
+            });
+        }
+
+        /// <summary>
+        /// </summary>
+        public static object GetAvailablePatterns(ToolRequest tool)
+        {
+            IntentRecognizer.Initialize();
+
+            var patterns = new List<string>();
+            if (tool.Parameters.TryGetValue("query", out object queryObj) && queryObj != null)
+            {
+                string query = queryObj.ToString();
+                string patternName = IntentRecognizer.RecognizeIntent(query);
+                if (!string.IsNullOrEmpty(patternName))
+                {
+                    patterns.Add(patternName);
+                }
+            }
+            else
+            {
+            }
+
+            return Response.Ok(patterns);
+        }
+    }
+}

--- a/src/McpGrasshopperPlugin/Utils/FuzzyMatcher.cs
+++ b/src/McpGrasshopperPlugin/Utils/FuzzyMatcher.cs
@@ -1,0 +1,166 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GH_MCP.Utils
+{
+    /// <summary>
+    /// Utility helpers for fuzzy matching component and parameter names.
+    /// </summary>
+    public static class FuzzyMatcher
+    {
+        // Map simplified names to actual Grasshopper component names
+        private static readonly Dictionary<string, string> ComponentNameMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            // Plane components
+            { "plane", "XY Plane" },
+            { "xyplane", "XY Plane" },
+            { "xy", "XY Plane" },
+            { "xzplane", "XZ Plane" },
+            { "xz", "XZ Plane" },
+            { "yzplane", "YZ Plane" },
+            { "yz", "YZ Plane" },
+            { "plane3pt", "Plane 3Pt" },
+            { "3ptplane", "Plane 3Pt" },
+            
+            // Basic geometry components
+            { "box", "Box" },
+            { "cube", "Box" },
+            { "rectangle", "Rectangle" },
+            { "rect", "Rectangle" },
+            { "circle", "Circle" },
+            { "circ", "Circle" },
+            { "sphere", "Sphere" },
+            { "cylinder", "Cylinder" },
+            { "cyl", "Cylinder" },
+            { "cone", "Cone" },
+            
+            // Parameter components
+            { "slider", "Number Slider" },
+            { "numberslider", "Number Slider" },
+            { "panel", "Panel" },
+            { "point", "Point" },
+            { "pt", "Point" },
+            { "line", "Line" },
+            { "ln", "Line" },
+            { "curve", "Curve" },
+            { "crv", "Curve" }
+        };
+        
+        // Map simplified parameter names to Grasshopper parameters
+        private static readonly Dictionary<string, string> ParameterNameMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            // Plane parameters
+            { "plane", "Plane" },
+            { "base", "Base" },
+            { "origin", "Origin" },
+            
+            // Dimension parameters
+            { "radius", "Radius" },
+            { "r", "Radius" },
+            { "size", "Size" },
+            { "xsize", "X Size" },
+            { "ysize", "Y Size" },
+            { "zsize", "Z Size" },
+            { "width", "X Size" },
+            { "length", "Y Size" },
+            { "height", "Z Size" },
+            { "x", "X" },
+            { "y", "Y" },
+            { "z", "Z" },
+            
+            // Point parameters
+            { "point", "Point" },
+            { "pt", "Point" },
+            { "center", "Center" },
+            { "start", "Start" },
+            { "end", "End" },
+            
+            // Numeric parameters
+            { "number", "Number" },
+            { "num", "Number" },
+            { "value", "Value" },
+            
+            // Output parameters
+            { "result", "Result" },
+            { "output", "Output" },
+            { "geometry", "Geometry" },
+            { "geo", "Geometry" },
+            { "brep", "Brep" }
+        };
+        
+        /// <summary>
+        /// Gets the closest matching component name.
+        /// </summary>
+        /// <param name="input">Input component name</param>
+        /// <returns>The mapped component name</returns>
+        public static string GetClosestComponentName(string input)
+        {
+            if (string.IsNullOrWhiteSpace(input))
+                return input;
+                
+            // Try to map directly
+            string normalizedInput = input.ToLowerInvariant().Replace(" ", "").Replace("_", "");
+            if (ComponentNameMap.TryGetValue(normalizedInput, out string mappedName))
+                return mappedName;
+                
+            // If no mapping was found return the original input
+            return input;
+        }
+        
+        /// <summary>
+        /// Gets the closest matching parameter name.
+        /// </summary>
+        /// <param name="input">Input parameter name</param>
+        /// <returns>The mapped parameter name</returns>
+        public static string GetClosestParameterName(string input)
+        {
+            if (string.IsNullOrWhiteSpace(input))
+                return input;
+                
+            // Try to map directly
+            string normalizedInput = input.ToLowerInvariant().Replace(" ", "").Replace("_", "");
+            if (ParameterNameMap.TryGetValue(normalizedInput, out string mappedName))
+                return mappedName;
+                
+            // If no mapping was found return the original input
+            return input;
+        }
+        
+        /// <summary>
+        /// Finds the closest string from a list of candidates.
+        /// </summary>
+        /// <param name="input">Input string</param>
+        /// <param name="candidates">Candidate list</param>
+        /// <returns>The closest string</returns>
+        public static string FindClosestMatch(string input, IEnumerable<string> candidates)
+        {
+            if (string.IsNullOrWhiteSpace(input) || candidates == null || !candidates.Any())
+                return input;
+                
+            // First try exact match
+            var exactMatch = candidates.FirstOrDefault(c => string.Equals(c, input, StringComparison.OrdinalIgnoreCase));
+            if (exactMatch != null)
+                return exactMatch;
+                
+            // Then check if any candidate contains the input
+            var containsMatches = candidates.Where(c => c.IndexOf(input, StringComparison.OrdinalIgnoreCase) >= 0).ToList();
+            if (containsMatches.Count == 1)
+                return containsMatches[0];
+                
+            // Then check prefix match
+            var prefixMatches = candidates.Where(c => c.StartsWith(input, StringComparison.OrdinalIgnoreCase)).ToList();
+            if (prefixMatches.Count == 1)
+                return prefixMatches[0];
+                
+            // If multiple matches exist, return the shortest one
+            if (containsMatches.Any())
+                return containsMatches.OrderBy(c => c.Length).First();
+                
+            // If nothing matched, return the original input
+            return input;
+        }
+    }
+}

--- a/src/McpGrasshopperPlugin/Utils/IntentRecognizer.cs
+++ b/src/McpGrasshopperPlugin/Utils/IntentRecognizer.cs
@@ -1,0 +1,236 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Rhino;
+using GH_MCP.Models;
+
+namespace GH_MCP.Utils
+{
+    /// <summary>
+    /// Recognizes user intent descriptions and converts them into
+    /// component and connection details.
+    /// </summary>
+    public class IntentRecognizer
+    {
+        private static JObject _knowledgeBase;
+        private static readonly string _knowledgeBasePath = Path.Combine(
+            Path.GetDirectoryName(typeof(IntentRecognizer).Assembly.Location),
+            "Resources",
+            "ComponentKnowledgeBase.json"
+        );
+
+        /// <summary>
+        /// Initializes the knowledge base
+        /// </summary>
+        public static void Initialize()
+        {
+            try
+            {
+                if (File.Exists(_knowledgeBasePath))
+                {
+                    string json = File.ReadAllText(_knowledgeBasePath);
+                    _knowledgeBase = JObject.Parse(json);
+                    RhinoApp.WriteLine($"Component knowledge base loaded from {_knowledgeBasePath}");
+                }
+                else
+                {
+                    RhinoApp.WriteLine($"Component knowledge base not found at {_knowledgeBasePath}");
+                    _knowledgeBase = new JObject();
+                }
+            }
+            catch (Exception ex)
+            {
+                RhinoApp.WriteLine($"Error loading component knowledge base: {ex.Message}");
+                _knowledgeBase = new JObject();
+            }
+        }
+
+        /// <summary>
+        /// Identifies an intent from a user description
+        /// </summary>
+        /// <param name="description">User description</param>
+        /// <returns>The matched pattern name or null</returns>
+        public static string RecognizeIntent(string description)
+        {
+            if (_knowledgeBase == null)
+            {
+                Initialize();
+            }
+
+            if (_knowledgeBase["intents"] == null)
+            {
+                return null;
+            }
+
+            // Break description into lowercase words
+            string[] words = description.ToLowerInvariant().Split(
+                new[] { ' ', ',', '.', ';', ':', '!', '?', '(', ')', '[', ']', '{', '}' },
+                StringSplitOptions.RemoveEmptyEntries
+            );
+
+            // Compute a score for each intent
+            var intentScores = new Dictionary<string, int>();
+
+            foreach (var intent in _knowledgeBase["intents"])
+            {
+                string patternName = intent["pattern"].ToString();
+                var keywords = intent["keywords"].ToObject<List<string>>();
+
+                // Count matching keywords
+                int matchCount = words.Count(word => keywords.Contains(word));
+
+                if (matchCount > 0)
+                {
+                    intentScores[patternName] = matchCount;
+                }
+            }
+
+            // Return the highest scoring intent
+            if (intentScores.Count > 0)
+            {
+                return intentScores.OrderByDescending(pair => pair.Value).First().Key;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Gets components and connections for a pattern
+        /// </summary>
+        /// <param name="patternName">Pattern name</param>
+        /// <returns>Tuple containing components and connections</returns>
+        public static (List<ComponentInfo> Components, List<ConnectionInfo> Connections) GetPatternDetails(string patternName)
+        {
+            if (_knowledgeBase == null)
+            {
+                Initialize();
+            }
+
+            var components = new List<ComponentInfo>();
+            var connections = new List<ConnectionInfo>();
+
+            if (_knowledgeBase["patterns"] == null)
+            {
+                return (components, connections);
+            }
+
+            // Find the matching pattern
+            var pattern = _knowledgeBase["patterns"].FirstOrDefault(p => p["name"].ToString() == patternName);
+            if (pattern == null)
+            {
+                return (components, connections);
+            }
+
+            // Read component info
+            foreach (var comp in pattern["components"])
+            {
+                var componentInfo = new ComponentInfo
+                {
+                    Type = comp["type"].ToString(),
+                    X = comp["x"].Value<double>(),
+                    Y = comp["y"].Value<double>(),
+                    Id = comp["id"].ToString()
+                };
+
+                // Add optional settings
+                if (comp["settings"] != null)
+                {
+                    componentInfo.Settings = comp["settings"].ToObject<Dictionary<string, object>>();
+                }
+
+                components.Add(componentInfo);
+            }
+
+            // Read connection info
+            foreach (var conn in pattern["connections"])
+            {
+                connections.Add(new ConnectionInfo
+                {
+                    SourceId = conn["source"].ToString(),
+                    SourceParam = conn["sourceParam"].ToString(),
+                    TargetId = conn["target"].ToString(),
+                    TargetParam = conn["targetParam"].ToString()
+                });
+            }
+
+            return (components, connections);
+        }
+
+        /// <summary>
+        /// Gets all available component types
+        /// </summary>
+        /// <returns>List of types</returns>
+        public static List<string> GetAvailableComponentTypes()
+        {
+            if (_knowledgeBase == null)
+            {
+                Initialize();
+            }
+
+            var types = new List<string>();
+
+            if (_knowledgeBase["components"] != null)
+            {
+                foreach (var comp in _knowledgeBase["components"])
+                {
+                    types.Add(comp["name"].ToString());
+                }
+            }
+
+            return types;
+        }
+
+        /// <summary>
+        /// Gets detailed information about a component type.
+        /// </summary>
+        /// <param name="componentType">Component type</param>
+        /// <returns>Component details</returns>
+        public static JObject GetComponentDetails(string componentType)
+        {
+            if (_knowledgeBase == null)
+            {
+                Initialize();
+            }
+
+            if (_knowledgeBase["components"] != null)
+            {
+                var component = _knowledgeBase["components"].FirstOrDefault(
+                    c => c["name"].ToString().Equals(componentType, StringComparison.OrdinalIgnoreCase)
+                );
+
+                if (component != null)
+                {
+                    return JObject.FromObject(component);
+                }
+            }
+
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Represents a component definition
+    /// </summary>
+    public class ComponentInfo
+    {
+        public string Type { get; set; }
+        public double X { get; set; }
+        public double Y { get; set; }
+        public string Id { get; set; }
+        public Dictionary<string, object> Settings { get; set; }
+    }
+
+    /// <summary>
+    /// Represents a connection description
+    /// </summary>
+    public class ConnectionInfo
+    {
+        public string SourceId { get; set; }
+        public string SourceParam { get; set; }
+        public string TargetId { get; set; }
+        public string TargetParam { get; set; }
+    }
+}

--- a/src/ModelContextProtocol.HttpListener/HttpListenerMcpTransport.cs
+++ b/src/ModelContextProtocol.HttpListener/HttpListenerMcpTransport.cs
@@ -1,0 +1,219 @@
+using ModelContextProtocol.Server;
+using ModelContextProtocol.Protocol;
+using Microsoft.Extensions.Logging;
+using System.Net;
+using System.Text.Json;
+using System.Collections.Concurrent;
+
+namespace ModelContextProtocol.HttpListener;
+
+/// <summary>
+/// Minimal HTTP listener based MCP server using SSE and JSON POST endpoints.
+/// </summary>
+/// <summary>
+/// HTTP transport for the MCP server built on <see cref="System.Net.HttpListener"/>.
+/// </summary>
+public sealed class HttpListenerMcpTransport : IServerTransport
+{
+    private readonly HttpListener _listener = new();
+    private readonly McpServerOptions _options;
+    private readonly ILoggerFactory? _loggerFactory;
+    private readonly IServiceProvider? _serviceProvider;
+    private readonly string _basePath;
+    private readonly string _streamPath;
+    private readonly string _messagePath;
+    private readonly ConcurrentDictionary<string, HttpSession> _sessions = new();
+    private CancellationTokenSource? _cts;
+    private Task? _listenTask;
+
+    /// <summary>
+    /// Occurs whenever a JSON-RPC message is received via the <c>/mcp/message</c> endpoint.
+    /// </summary>
+    public event Action<JsonRpcMessage>? MessageReceived;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HttpListenerMcpTransport"/> class.
+    /// </summary>
+    /// <param name="prefix">The HTTP prefix that the listener should bind to. Must end with a '/'.</param>
+    /// <param name="options">Options used when creating <see cref="IMcpServer"/> instances.</param>
+    /// <param name="loggerFactory">Optional logger factory for the MCP server.</param>
+    public HttpListenerMcpTransport(string prefix, McpServerOptions options, ILoggerFactory? loggerFactory = null, IServiceProvider? serviceProvider = null)
+    {
+        _options = options;
+        _loggerFactory = loggerFactory;
+        _serviceProvider = serviceProvider;
+        _listener.Prefixes.Add(prefix);
+
+        var uri = new Uri(prefix);
+        _basePath = uri.AbsolutePath.TrimEnd('/') + "/";
+        _streamPath = _basePath + "stream";
+        _messagePath = _basePath + "message";
+    }
+
+    /// <summary>
+    /// Begins listening for incoming HTTP requests.
+    /// </summary>
+    /// <param name="cancellationToken">Token used to stop the listener.</param>
+    public Task StartAsync(CancellationToken cancellationToken = default)
+    {
+        if (_cts is not null)
+            throw new InvalidOperationException("Server already started");
+        _cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        _listener.Start();
+        _listenTask = Task.Run(() => ListenLoopAsync(_cts.Token));
+        return Task.CompletedTask;
+    }
+
+    private async Task ListenLoopAsync(CancellationToken token)
+    {
+        while (!token.IsCancellationRequested)
+        {
+            HttpListenerContext context;
+            try
+            {
+                context = await _listener.GetContextAsync().WaitAsync(token);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+            _ = Task.Run(() => HandleContextAsync(context, token));
+        }
+    }
+
+    private async Task HandleContextAsync(HttpListenerContext context, CancellationToken token)
+    {
+        string path = context.Request.Url?.AbsolutePath ?? "/";
+        if (path.Equals(_streamPath, StringComparison.OrdinalIgnoreCase) && context.Request.HttpMethod == "GET")
+        {
+            await HandleSseAsync(context, token);
+            return;
+        }
+        if (path.Equals(_messagePath, StringComparison.OrdinalIgnoreCase) && context.Request.HttpMethod == "POST")
+        {
+            await HandleMessageAsync(context, token);
+            return;
+        }
+
+        context.Response.StatusCode = (int)HttpStatusCode.NotFound;
+        context.Response.Close();
+    }
+
+    private async Task HandleSseAsync(HttpListenerContext context, CancellationToken token)
+    {
+        string sessionId = Guid.NewGuid().ToString("N");
+        context.Response.ContentType = "text/event-stream";
+        context.Response.Headers["Cache-Control"] = "no-cache";
+        context.Response.Headers["mcp-session-id"] = sessionId;
+
+        await using var transport = new SseResponseStreamTransport(context.Response.OutputStream, $"{_messagePath}?sessionId={sessionId}", sessionId);
+        await using var server = McpServerFactory.Create(transport, _options, _loggerFactory, _serviceProvider);
+        var session = new HttpSession(sessionId, transport, server);
+        if (!_sessions.TryAdd(sessionId, session))
+        {
+            context.Response.StatusCode = (int)HttpStatusCode.InternalServerError;
+            context.Response.Close();
+            return;
+        }
+
+        try
+        {
+            var transportTask = transport.RunAsync(token);
+            var serverTask = server.RunAsync(token);
+            await Task.WhenAll(transportTask, serverTask);
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        finally
+        {
+            _sessions.TryRemove(sessionId, out _);
+            context.Response.Close();
+        }
+    }
+
+    private async Task HandleMessageAsync(HttpListenerContext context, CancellationToken token)
+    {
+        string? sessionId = context.Request.QueryString["sessionId"];
+        if (sessionId is null || !_sessions.TryGetValue(sessionId, out var session))
+        {
+            context.Response.StatusCode = (int)HttpStatusCode.BadRequest;
+            context.Response.Close();
+            return;
+        }
+
+        using var doc = await JsonDocument.ParseAsync(context.Request.InputStream, cancellationToken: token);
+        if (doc.RootElement.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var element in doc.RootElement.EnumerateArray())
+            {
+                if (element.Deserialize<JsonRpcMessage>(McpJsonUtilities.DefaultOptions) is { } msg)
+                {
+                    MessageReceived?.Invoke(msg);
+                    await session.Transport.OnMessageReceivedAsync(msg, token);
+                }
+            }
+        }
+        else
+        {
+            if (doc.RootElement.Deserialize<JsonRpcMessage>(McpJsonUtilities.DefaultOptions) is { } msg)
+            {
+                MessageReceived?.Invoke(msg);
+                await session.Transport.OnMessageReceivedAsync(msg, token);
+            }
+        }
+        context.Response.StatusCode = (int)HttpStatusCode.Accepted;
+        context.Response.Close();
+    }
+
+    /// <summary>
+    /// Stops listening for requests and releases all resources.
+    /// </summary>
+    public async Task StopAsync()
+    {
+        if (_cts is not null)
+        {
+            _cts.Cancel();
+            _listener.Stop();
+            if (_listenTask is not null)
+            {
+                await _listenTask.ConfigureAwait(false);
+            }
+            _cts.Dispose();
+            _cts = null;
+        }
+    }
+
+    /// <summary>
+    /// Disposes the transport and any active sessions.
+    /// </summary>
+    public async ValueTask DisposeAsync()
+    {
+        await StopAsync().ConfigureAwait(false);
+
+        foreach (var session in _sessions.Values)
+        {
+            await session.DisposeAsync();
+        }
+        _sessions.Clear();
+    }
+
+    private sealed class HttpSession : IAsyncDisposable
+    {
+        public string Id { get; }
+        public SseResponseStreamTransport Transport { get; }
+        public IMcpServer Server { get; }
+
+        public HttpSession(string id, SseResponseStreamTransport transport, IMcpServer server)
+        {
+            Id = id;
+            Transport = transport;
+            Server = server;
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            return Server.DisposeAsync();
+        }
+    }
+}

--- a/src/ModelContextProtocol.HttpListener/IServerTransport.cs
+++ b/src/ModelContextProtocol.HttpListener/IServerTransport.cs
@@ -1,0 +1,14 @@
+namespace ModelContextProtocol.HttpListener;
+
+/// <summary>
+/// Defines basic lifecycle control for an MCP server transport.
+/// </summary>
+public interface IServerTransport : IAsyncDisposable
+{
+    /// <summary>Starts accepting HTTP requests.</summary>
+    /// <param name="cancellationToken">Token to monitor for cancellation.</param>
+    Task StartAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>Stops listening and releases all resources.</summary>
+    Task StopAsync();
+}

--- a/src/ModelContextProtocol.HttpListener/ModelContextProtocol.HttpListener.csproj
+++ b/src/ModelContextProtocol.HttpListener/ModelContextProtocol.HttpListener.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../ModelContextProtocol.Core/ModelContextProtocol.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/ModelContextProtocol.HttpListener/README.md
+++ b/src/ModelContextProtocol.HttpListener/README.md
@@ -1,0 +1,27 @@
+# HttpListener MCP Transport
+
+This library provides an `HttpListener` based implementation of the MCP server transport.
+It targets **.NET Standard 2.0** so it can be used from applications running on .NET Framework 4.8.
+The listener exposes two endpoints relative to the configured prefix:
+
+* `GET {prefix}stream` - Server-Sent Events stream of responses
+* `POST {prefix}message` - Accepts JSON-RPC messages
+
+```csharp
+var transport = new HttpListenerMcpTransport("http://localhost:5000/mcp/", new McpServerOptions());
+transport.MessageReceived += msg => Console.WriteLine(msg.Method);
+await transport.StartAsync();
+```
+
+A Grasshopper component can use the transport as follows:
+
+```csharp
+var options = new McpServerOptions();
+listener = new HttpListenerMcpTransport(prefix, options);
+listener.MessageReceived += msg =>
+{
+    messages.Add(JsonSerializer.Serialize(msg, McpJsonUtilities.DefaultOptions.GetTypeInfo(typeof(JsonRpcMessage))));
+    ExpireSolution(true);
+};
+await listener.StartAsync();
+```


### PR DESCRIPTION
## Summary
- rename `Commands` folder to `Tools` in the Grasshopper plugin
- rename all command handler files to ToolHandler files
- update `GrasshopperToolRegistry` to reference ToolHandlers and improved error text

## Testing
- `dotnet restore`
- `dotnet build --no-restore`
- `DOTNET_ROOT=$HOME/.dotnet make test`

------
https://chatgpt.com/codex/tasks/task_e_684ef2009d5083268f0cd735f9e95575