### PR TITLE
Update CI for Grasshopper plugin

### DIFF
--- a/.github/workflows/ci-build-test.yml
+++ b/.github/workflows/ci-build-test.yml
@@ -64,8 +64,21 @@ jobs:
     - name: Build
       run: dotnet build --configuration ${{ matrix.configuration }}
 
+    - name: Build Grasshopper plugin
+      run: dotnet build src/McpGrasshopperPlugin/McpGrasshopperPlugin.csproj --configuration ${{ matrix.configuration }}
+
     - name: Pack
       run: dotnet pack --configuration ${{ matrix.configuration }}
+
+    - name: Pack Grasshopper plugin
+      run: dotnet pack src/McpGrasshopperPlugin/McpGrasshopperPlugin.csproj --configuration ${{ matrix.configuration }}
+
+    - name: Upload Grasshopper plugin artifact
+      if: always()
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      with:
+        name: grasshopper-plugin-${{ matrix.os }}-${{ matrix.configuration }}
+        path: src/McpGrasshopperPlugin/bin/${{ matrix.configuration }}/**/*.gha
 
     - name: Test
       run: >-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,6 +86,12 @@ jobs:
           --configuration Release
           --output "${{ github.workspace }}/artifacts/packages"
 
+      - name: Pack Grasshopper plugin
+        run: dotnet pack src/McpGrasshopperPlugin/McpGrasshopperPlugin.csproj
+          ${{ env.version_suffix_args }}
+          --configuration Release
+          --output "${{ github.workspace }}/artifacts/grasshopper"
+
       - name: Upload artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: ${{ !cancelled() }}
@@ -147,8 +153,10 @@ jobs:
         uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
 
       - name: Upload release asset
-        run: gh release upload ${{ github.event.release.tag_name }}
-          ${{ github.workspace }}/build-artifacts/packages/*.*nupkg
+        run: |
+          gh release upload ${{ github.event.release.tag_name }} \
+            ${{ github.workspace }}/build-artifacts/packages/*.*nupkg \
+            ${{ github.workspace }}/build-artifacts/grasshopper/**/*.gha
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary
- build the Grasshopper plugin in CI and publish artifact
- include Grasshopper plugin in release packaging

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f2d19efb4832697aa7225f43e67fb