### PR TITLE
Add HttpListener transport tests and sample client

### DIFF
--- a/samples/HttpListenerClient/HttpListenerClient.csproj
+++ b/samples/HttpListenerClient/HttpListenerClient.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../src/ModelContextProtocol.Core/ModelContextProtocol.Core.csproj" />
+    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" />
+  </ItemGroup>
+</Project>

--- a/samples/HttpListenerClient/Program.cs
+++ b/samples/HttpListenerClient/Program.cs
@@ -1,0 +1,39 @@
+using ModelContextProtocol.Client;
+using OpenAI;
+
+// Simple client that connects to an MCP server using the HttpListener transport.
+// The server is expected to expose the /mcp/stream and /mcp/message endpoints.
+
+var openAiKey = Environment.GetEnvironmentVariable("OPENAI_API_KEY");
+var transportOptions = new SseClientTransportOptions
+{
+    Endpoint = new Uri("http://localhost:5000/mcp/stream"),
+    Name = "HttpListenerServer",
+    TransportMode = HttpTransportMode.Sse,
+};
+
+await using var client = await McpClientFactory.CreateAsync(new SseClientTransport(transportOptions));
+
+Console.WriteLine("Connected to server. Available tools:");
+var tools = await client.ListToolsAsync();
+foreach (var tool in tools)
+{
+    Console.WriteLine($"- {tool.Name}");
+}
+
+Console.WriteLine();
+Console.WriteLine("Type a message to send to the echo tool (empty line to quit):");
+string? line;
+while (!string.IsNullOrEmpty(line = Console.ReadLine()))
+{
+    var result = await client.CallToolAsync("echo", new Dictionary<string, object?> { ["message"] = line });
+    Console.WriteLine(string.Join("\n", result.Content.Select(c => c.Text)));
+    Console.WriteLine();
+}
+
+if (!string.IsNullOrEmpty(openAiKey))
+{
+    // Example of creating an OpenAI chat client using the secret key
+    var chatClient = new OpenAIClient(openAiKey).GetChatClient("gpt-4o-mini");
+    Console.WriteLine($"OpenAI client created for model {chatClient.Model}");
+}

--- a/src/ModelContextProtocol.HttpListener/HttpListenerMcpTransport.cs
+++ b/src/ModelContextProtocol.HttpListener/HttpListenerMcpTransport.cs
@@ -15,7 +15,7 @@ namespace ModelContextProtocol.HttpListener;
 /// </summary>
 public sealed class HttpListenerMcpTransport : IServerTransport
 {
-    private readonly HttpListener _listener = new();
+    private readonly System.Net.HttpListener _listener = new();
     private readonly McpServerOptions _options;
     private readonly ILoggerFactory? _loggerFactory;
     private readonly IServiceProvider? _serviceProvider;
@@ -71,7 +71,15 @@ public sealed class HttpListenerMcpTransport : IServerTransport
             HttpListenerContext context;
             try
             {
+#if NETSTANDARD2_0
+                context = await _listener.GetContextAsync();
+                if (token.IsCancellationRequested)
+                {
+                    break;
+                }
+#else
                 context = await _listener.GetContextAsync().WaitAsync(token);
+#endif
             }
             catch (OperationCanceledException)
             {

--- a/src/ModelContextProtocol.HttpListener/ModelContextProtocol.HttpListener.csproj
+++ b/src/ModelContextProtocol.HttpListener/ModelContextProtocol.HttpListener.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>net9.0;net8.0;netstandard2.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/tests/ModelContextProtocol.Tests/ModelContextProtocol.Tests.csproj
+++ b/tests/ModelContextProtocol.Tests/ModelContextProtocol.Tests.csproj
@@ -58,6 +58,7 @@
     <ProjectReference Include="..\..\src\ModelContextProtocol.Core\ModelContextProtocol.Core.csproj" />
     <ProjectReference Include="..\ModelContextProtocol.TestServer\ModelContextProtocol.TestServer.csproj" />
     <ProjectReference Include="..\..\samples\TestServerWithHosting\TestServerWithHosting.csproj" />
+    <ProjectReference Include="..\..\src\ModelContextProtocol.HttpListener\ModelContextProtocol.HttpListener.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/ModelContextProtocol.Tests/Transport/HttpListenerMcpTransportTests.cs
+++ b/tests/ModelContextProtocol.Tests/Transport/HttpListenerMcpTransportTests.cs
@@ -1,0 +1,125 @@
+using ModelContextProtocol.HttpListener;
+using ModelContextProtocol.Server;
+using ModelContextProtocol.Client;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Tests.Utils;
+using System.Net;
+using System.Text.Json;
+
+namespace ModelContextProtocol.Tests.Transport;
+
+public class HttpListenerMcpTransportTests(ITestOutputHelper outputHelper) : LoggedTest(outputHelper)
+{
+    private static int GetFreePort()
+    {
+        var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+
+    private static McpServerOptions CreateServerOptions()
+    {
+        return new McpServerOptions
+        {
+            Capabilities = new ServerCapabilities
+            {
+                Tools = new()
+                {
+                    ListToolsHandler = async (_, _) => new ListToolsResult
+                    {
+                        Tools =
+                        [
+                            new Tool
+                            {
+                                Name = "echo",
+                                Description = "Echoes the input back to the client.",
+                                InputSchema = JsonSerializer.Deserialize<JsonElement>("""
+                                    {
+                                        "type": "object",
+                                        "properties": {
+                                            "message": {"type": "string"}
+                                        },
+                                        "required": ["message"]
+                                    }
+                                """, McpJsonUtilities.DefaultOptions),
+                            },
+                            new Tool
+                            {
+                                Name = "echoSessionId",
+                                Description = "Returns the current session id.",
+                                InputSchema = JsonSerializer.Deserialize<JsonElement>("""
+                                    {"type": "object"}
+                                """, McpJsonUtilities.DefaultOptions),
+                            }
+                        ]
+                    },
+                    CallToolHandler = async (request, _) =>
+                    {
+                        if (request.Params is null)
+                            throw new McpException("Missing params", McpErrorCode.InvalidParams);
+
+                        return request.Params.Name switch
+                        {
+                            "echo" when request.Params.Arguments?.TryGetValue("message", out var msg) == true
+                                => new CallToolResponse { Content = [ new Content { Type = "text", Text = $"Echo: {msg}" } ] },
+                            "echoSessionId" => new CallToolResponse { Content = [ new Content { Type = "text", Text = request.Server.SessionId } ] },
+                            _ => throw new McpException("Invalid tool", McpErrorCode.InvalidParams)
+                        };
+                    }
+                }
+            },
+            ServerInfo = new Implementation { Name = "HttpListenerTest", Version = "1.0" },
+        };
+    }
+
+    private async Task<(HttpListenerMcpTransport transport, IMcpClient client)> StartServerAndClientAsync()
+    {
+        int port = GetFreePort();
+        var options = CreateServerOptions();
+        var prefix = $"http://localhost:{port}/mcp/";
+        var transport = new HttpListenerMcpTransport(prefix, options, LoggerFactory);
+        await transport.StartAsync(TestContext.Current.CancellationToken);
+
+        var clientOptions = new SseClientTransportOptions
+        {
+            Endpoint = new Uri($"http://localhost:{port}/mcp/stream"),
+            Name = "HttpListenerClient",
+            TransportMode = HttpTransportMode.Sse,
+        };
+        var client = await McpClientFactory.CreateAsync(
+            new SseClientTransport(clientOptions),
+            loggerFactory: LoggerFactory,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        return (transport, client);
+    }
+
+    [Fact]
+    public async Task ConnectAndPing()
+    {
+        var (transport, client) = await StartServerAndClientAsync();
+        await using var t = transport;
+        await using var c = client;
+
+        await c.PingAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task EchoTool_ReturnsEcho()
+    {
+        var (transport, client) = await StartServerAndClientAsync();
+        await using var t = transport;
+        await using var c = client;
+
+        var result = await c.CallToolAsync(
+            "echo",
+            new Dictionary<string, object?> { ["message"] = "hello" },
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        var content = Assert.Single(result.Content);
+        Assert.Equal("text", content.Type);
+        Assert.Equal("Echo: hello", content.Text);
+    }
+}


### PR DESCRIPTION
## Summary
- add new integration tests for `HttpListenerMcpTransport`
- add sample `HttpListenerClient` to demonstrate connecting to an HttpListener server
- fix namespace clash and multi-target HttpListener project
- ensure `Implementation.Version` is specified in tests

## Testing
- `dotnet build --configuration Debug --no-restore`
- `dotnet test --no-build --logger "console;verbosity=normal"`

------
https://chatgpt.com/codex/tasks/task_e_684f538886b883268910cc6be3f44a48